### PR TITLE
CTCP-531: Add graph for combining multiple entries, assuming they're all single entries

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/models/DeclarationData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/DeclarationData.scala
@@ -16,4 +16,6 @@
 
 package uk.gov.hmrc.transitmovements.models
 
-case class DeclarationData(movementEoriNumber: EORINumber)
+import java.time.OffsetDateTime
+
+case class DeclarationData(movementEoriNumber: EORINumber, generationDate: OffsetDateTime)

--- a/app/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingService.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingService.scala
@@ -17,12 +17,16 @@
 package uk.gov.hmrc.transitmovements.services
 
 import akka.NotUsed
+import akka.stream.FlowShape
 import akka.stream.Materializer
 import akka.stream.alpakka.xml.ParseEvent
 import akka.stream.alpakka.xml.scaladsl.XmlParsing
+import akka.stream.scaladsl.Broadcast
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.GraphDSL
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.ZipWith
 import akka.util.ByteString
 import cats.data.EitherT
 import com.google.inject.ImplementedBy
@@ -32,6 +36,9 @@ import uk.gov.hmrc.transitmovements.models.DeclarationData
 import uk.gov.hmrc.transitmovements.models.EORINumber
 import uk.gov.hmrc.transitmovements.services.errors.ParseError
 
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -47,41 +54,73 @@ trait DeparturesXmlParsingService {
 @Singleton
 class DeparturesXmlParsingServiceImpl @Inject() (implicit materializer: Materializer) extends DeparturesXmlParsingService {
 
+  type ParseResult[A] = Either[ParseError, A]
+
+  implicit private class FlowOps[A](value: Flow[ParseEvent, A, NotUsed]) {
+
+    def single(element: String): Flow[ParseEvent, ParseResult[A], NotUsed] =
+      value.fold[Either[ParseError, A]](Left(ParseError.NoElementFound(element)))(
+        (current, next) =>
+          current match {
+            case Left(ParseError.NoElementFound(_)) => Right(next)
+            case _                                  => Left(ParseError.TooManyElementsFound(element))
+          }
+      )
+  }
+
   // we don't want to starve the Play pool
   implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
-  private val movementEORINumberExtractor: Flow[ParseEvent, EORINumber, NotUsed] = XmlParsing
+  private val movementEORINumberExtractor: Flow[ParseEvent, ParseResult[EORINumber], NotUsed] = XmlParsing
     .subtree("CC015C" :: "messageSender" :: Nil) // TODO: see if we can get the EORI from the XSD in the future
     .collect {
       case element if element.getTextContent.nonEmpty => EORINumber(element.getTextContent)
     }
+    .single("messageSender")
 
-  private val declarationFlow: Flow[ByteString, DeclarationData, NotUsed] = XmlParsing.parser
-    .via(movementEORINumberExtractor)
-    .via(
-      Flow.fromFunction(
-        in => DeclarationData(in)
-      )
+  private val preparationDateTimeExtractor: Flow[ParseEvent, ParseResult[OffsetDateTime], NotUsed] = XmlParsing
+    .subtree("CC015C" :: "preparationDateAndTime" :: Nil)
+    .collect {
+      case element if element.getTextContent.nonEmpty =>
+        LocalDateTime.parse(element.getTextContent).atOffset(ZoneOffset.UTC)
+    }
+    .single("preparationDateAndTime")
+
+  private def buildDeclarationData(eoriMaybe: ParseResult[EORINumber], dateMaybe: ParseResult[OffsetDateTime]): ParseResult[DeclarationData] =
+    for {
+      eoriNumber     <- eoriMaybe
+      generationDate <- dateMaybe
+    } yield DeclarationData(eoriNumber, generationDate)
+
+  private val declarationFlow: Flow[ByteString, ParseResult[DeclarationData], NotUsed] =
+    Flow.fromGraph(
+      GraphDSL.create() {
+        implicit builder =>
+          import GraphDSL.Implicits._
+
+          val broadcast = builder.add(Broadcast[ParseEvent](2))
+          val combiner  = builder.add(ZipWith[ParseResult[EORINumber], ParseResult[OffsetDateTime], ParseResult[DeclarationData]](buildDeclarationData))
+
+          val xmlParsing = builder.add(XmlParsing.parser)
+          val eoriFlow   = builder.add(movementEORINumberExtractor)
+          val dateFlow   = builder.add(preparationDateTimeExtractor)
+
+          xmlParsing.out ~> broadcast.in
+          broadcast.out(0) ~> eoriFlow ~> combiner.in0
+          broadcast.out(1) ~> dateFlow ~> combiner.in1
+
+          FlowShape(xmlParsing.in, combiner.out)
+      }
     )
 
   override def extractDeclarationData(source: Source[ByteString, _]): EitherT[Future, ParseError, DeclarationData] =
     EitherT(
       source
         .via(declarationFlow)
-        .fold[Either[ParseError, DeclarationData]](Left(ParseError.NoElementFound("messageSender")))(
-          (current, next) =>
-            current match {
-              case Left(ParseError.NoElementFound(_)) => Right(next)
-              case _                                  => Left(ParseError.TooManyElementsFound("messageSender"))
-            }
-        )
         .recover {
           case NonFatal(e) => Left(ParseError.Unknown(Some(e)))
         }
-        .runWith(Sink.headOption[Either[ParseError, DeclarationData]])
-        .map(
-          result => result.getOrElse(Left(ParseError.NoElementFound("messageSender")))
-        )
+        .runWith(Sink.head[Either[ParseError, DeclarationData]])
     )
 
 }

--- a/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.services
+
+import akka.NotUsed
+import akka.stream.alpakka.xml.ParseEvent
+import akka.stream.alpakka.xml.scaladsl.XmlParsing
+import akka.stream.scaladsl.Flow
+import uk.gov.hmrc.transitmovements.models.EORINumber
+import uk.gov.hmrc.transitmovements.services.errors.ParseError
+
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
+
+object XmlParsers extends XmlParsingServiceHelpers {
+
+  val movementEORINumberExtractor: Flow[ParseEvent, ParseResult[EORINumber], NotUsed] = XmlParsing
+    .subtree("CC015C" :: "messageSender" :: Nil) // TODO: see if we can get the EORI from the XSD in the future
+    .collect {
+      case element if element.getTextContent.nonEmpty => EORINumber(element.getTextContent)
+    }
+    .single("messageSender")
+
+  val preparationDateTimeExtractor: Flow[ParseEvent, ParseResult[OffsetDateTime], NotUsed] = XmlParsing
+    .subtree("CC015C" :: "preparationDateAndTime" :: Nil)
+    .collect {
+      case element if element.getTextContent.nonEmpty =>
+        LocalDateTime.parse(element.getTextContent).atOffset(ZoneOffset.UTC)
+    }
+    .single("preparationDateAndTime")
+    .recover {
+      case exception: DateTimeParseException => Left(ParseError.BadDateTime("preparationDateAndTime", exception))
+    }
+
+}

--- a/app/uk/gov/hmrc/transitmovements/services/XmlParsingServiceHelpers.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/XmlParsingServiceHelpers.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.services
+
+import akka.NotUsed
+import akka.stream.alpakka.xml.ParseEvent
+import akka.stream.scaladsl.Flow
+import uk.gov.hmrc.transitmovements.services.errors.ParseError
+
+trait XmlParsingServiceHelpers {
+
+  type ParseResult[A] = Either[ParseError, A]
+
+  implicit class FlowOps[A](value: Flow[ParseEvent, A, NotUsed]) {
+
+    def single(element: String): Flow[ParseEvent, ParseResult[A], NotUsed] =
+      value.fold[Either[ParseError, A]](Left(ParseError.NoElementFound(element)))(
+        (current, next) =>
+          current match {
+            case Left(ParseError.NoElementFound(_)) => Right(next)
+            case _                                  => Left(ParseError.TooManyElementsFound(element))
+          }
+      )
+  }
+
+}

--- a/app/uk/gov/hmrc/transitmovements/services/errors/ParseError.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/errors/ParseError.scala
@@ -16,10 +16,13 @@
 
 package uk.gov.hmrc.transitmovements.services.errors
 
+import java.time.format.DateTimeParseException
+
 sealed abstract class ParseError
 
 object ParseError {
-  case class NoElementFound(element: String)                    extends ParseError
-  case class TooManyElementsFound(element: String)              extends ParseError
-  case class Unknown(caughtException: Option[Throwable] = None) extends ParseError
+  case class NoElementFound(element: String)                                 extends ParseError
+  case class TooManyElementsFound(element: String)                           extends ParseError
+  case class BadDateTime(element: String, exception: DateTimeParseException) extends ParseError
+  case class Unknown(caughtException: Option[Throwable] = None)              extends ParseError
 }

--- a/test/uk/gov/hmrc/transitmovements/base/StreamTestHelpers.scala
+++ b/test/uk/gov/hmrc/transitmovements/base/StreamTestHelpers.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.base
+
+import akka.stream.alpakka.xml.ParseEvent
+import akka.stream.alpakka.xml.scaladsl.XmlParsing
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+
+import java.nio.charset.StandardCharsets
+import scala.xml.NodeSeq
+
+object StreamTestHelpers extends StreamTestHelpers
+
+trait StreamTestHelpers {
+
+  def createStream(node: NodeSeq): Source[ByteString, _] = createStream(node.mkString)
+
+  def createStream(string: String): Source[ByteString, _] =
+    Source.single(ByteString(string, StandardCharsets.UTF_8))
+
+  def createParsingEventStream(node: NodeSeq): Source[ParseEvent, _] =
+    createStream(node).via(XmlParsing.parser)
+
+}

--- a/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
@@ -144,7 +144,7 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
           val error = result.left.get
           error mustBe a[ParseError.BadDateTime]
           error.asInstanceOf[ParseError.BadDateTime].element mustBe "preparationDateAndTime"
-          error.asInstanceOf[ParseError.BadDateTime].exception.getMessage mustBe "Text 'notadatetime' could not be parsed at index 0"
+          error.asInstanceOf[ParseError.BadDateTime].exception.getMessage mustBe "Text 'notadate' could not be parsed at index 0"
       }
     }
 

--- a/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
@@ -16,25 +16,22 @@
 
 package uk.gov.hmrc.transitmovements.services
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
 import com.fasterxml.aalto.WFCException
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import uk.gov.hmrc.transitmovements.base.StreamTestHelpers
 import uk.gov.hmrc.transitmovements.base.TestActorSystem
 import uk.gov.hmrc.transitmovements.models.DeclarationData
 import uk.gov.hmrc.transitmovements.models.EORINumber
 import uk.gov.hmrc.transitmovements.services.errors.ParseError
 
-import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import scala.xml.NodeSeq
 
-class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with Matchers with TestActorSystem with ScalaCheckPropertyChecks {
+class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with Matchers with TestActorSystem with StreamTestHelpers {
 
   private val testDate      = OffsetDateTime.now(ZoneOffset.UTC)
   private val UTCDateString = testDate.toLocalDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
@@ -77,11 +74,6 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
 
   val mismatchedTags: String =
     "<CC015C><messageSender>GB1234</messageReceiver></CC015C>"
-
-  private def createStream(node: NodeSeq): Source[ByteString, _] = createStream(node.mkString)
-
-  private def createStream(string: String): Source[ByteString, _] =
-    Source.single(ByteString(string, StandardCharsets.UTF_8))
 
   "When handed an XML stream" - {
     val service = new DeparturesXmlParsingServiceImpl

--- a/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.services
+
+import akka.stream.scaladsl.Sink
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import uk.gov.hmrc.transitmovements.base.StreamTestHelpers
+import uk.gov.hmrc.transitmovements.base.TestActorSystem
+import uk.gov.hmrc.transitmovements.models.EORINumber
+import uk.gov.hmrc.transitmovements.services.errors.ParseError
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import scala.xml.NodeSeq
+
+class XmlParsersSpec extends AnyFreeSpec with TestActorSystem with Matchers with StreamTestHelpers with ScalaFutures with ScalaCheckPropertyChecks {
+
+  "EORINumber parser" - {
+
+    val withEntry: NodeSeq =
+      <CC015C>
+        <messageSender>GB1234</messageSender>
+      </CC015C>
+
+    val withNoEntry: NodeSeq =
+      <CC015C>
+      </CC015C>
+
+    val withTwoEntries: NodeSeq =
+      <CC015C>
+        <messageSender>GB1234</messageSender>
+        <messageSender>XI1234</messageSender>
+      </CC015C>
+
+    "when provided with a valid entry" in {
+      val stream       = createParsingEventStream(withEntry)
+      val parsedResult = stream.via(XmlParsers.movementEORINumberExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Right(EORINumber("GB1234"))
+      }
+    }
+
+    "when provided with no entry" in {
+      val stream       = createParsingEventStream(withNoEntry)
+      val parsedResult = stream.via(XmlParsers.movementEORINumberExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Left(ParseError.NoElementFound("messageSender"))
+      }
+    }
+
+    "when provided with two entries" in {
+      val stream       = createParsingEventStream(withTwoEntries)
+      val parsedResult = stream.via(XmlParsers.movementEORINumberExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Left(ParseError.TooManyElementsFound("messageSender"))
+      }
+    }
+
+  }
+
+  "Preparation Date and Time parser" - {
+    val dateTime          = OffsetDateTime.now(ZoneOffset.UTC)
+    val formattedDateTime = dateTime.toLocalDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
+
+    val withEntry: NodeSeq =
+      <CC015C>
+        <preparationDateAndTime>{formattedDateTime}</preparationDateAndTime>
+      </CC015C>
+
+    val withDateParseError: NodeSeq =
+      <CC015C>
+        <preparationDateAndTime>notadatetime</preparationDateAndTime>
+      </CC015C>
+
+    val withNoEntry: NodeSeq =
+      <CC015C>
+      </CC015C>
+
+    val withTwoEntries: NodeSeq =
+      <CC015C>
+        <preparationDateAndTime>{formattedDateTime}</preparationDateAndTime>
+        <preparationDateAndTime>{formattedDateTime}</preparationDateAndTime>
+      </CC015C>
+
+    "when provided with a valid entry" in {
+      val stream       = createParsingEventStream(withEntry)
+      val parsedResult = stream.via(XmlParsers.preparationDateTimeExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Right(dateTime)
+      }
+    }
+
+    "when provided with no entry" in {
+      val stream       = createParsingEventStream(withNoEntry)
+      val parsedResult = stream.via(XmlParsers.preparationDateTimeExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Left(ParseError.NoElementFound("preparationDateAndTime"))
+      }
+    }
+
+    "when provided with two entries" in {
+      val stream       = createParsingEventStream(withTwoEntries)
+      val parsedResult = stream.via(XmlParsers.preparationDateTimeExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        _ mustBe Left(ParseError.TooManyElementsFound("preparationDateAndTime"))
+      }
+    }
+
+    "when provided with an unparsable entry" in {
+      val stream       = createParsingEventStream(withDateParseError)
+      val parsedResult = stream.via(XmlParsers.preparationDateTimeExtractor).runWith(Sink.head)
+
+      whenReady(parsedResult) {
+        result =>
+          val error = result.left.get
+          error mustBe a[ParseError.BadDateTime]
+          error.asInstanceOf[ParseError.BadDateTime].element mustBe "preparationDateAndTime"
+          error.asInstanceOf[ParseError.BadDateTime].exception.getMessage mustBe "Text 'notadatetime' could not be parsed at index 0"
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This now returns the preparation date/time as the generated time.

Also creates a `ParseResult[A]` type alias for `Either[ParseResult, A]` to shorten the code a little.