### PR TITLE
Remove Hello World controller from application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,12 +74,6 @@ play.http.router = prod.Routes
 controllers {
   # 300 is the default, you may need to change this according to your needs
   confidenceLevel = 300
-
-  uk.gov.hmrc.transitmovements.controllers.MicroserviceHelloWorldController = {
-    needsAuth = false
-    needsLogging = false
-    needsAuditing = false
-  }
 }
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis


### PR DESCRIPTION
Realised we needed to do this after https://github.com/hmrc/transit-movements-router/pull/2.