### PR TITLE
CTCP-306: Add TTL index for updated field in the departure collection

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
@@ -33,4 +33,5 @@ class AppConfig @Inject() (
   lazy val graphiteHost: String     = config.get[String]("microservice.metrics.graphite.host")
 
   lazy val mongoRetryAttempts: Int = config.get[Int]("mongodb.retryAttempts")
+  lazy val documentTtl: Long       = config.get[Long]("mongodb.timeToLiveInSeconds")
 }

--- a/app/uk/gov/hmrc/transitmovements/repositories/DeparturesRepository.scala
+++ b/app/uk/gov/hmrc/transitmovements/repositories/DeparturesRepository.scala
@@ -19,6 +19,9 @@ package uk.gov.hmrc.transitmovements.repositories
 import akka.pattern.retry
 import cats.data.EitherT
 import com.google.inject.ImplementedBy
+import org.mongodb.scala.model.IndexModel
+import org.mongodb.scala.model.IndexOptions
+import org.mongodb.scala.model.Indexes
 import org.mongodb.scala.result.InsertOneResult
 import play.api.Logging
 import uk.gov.hmrc.mongo.MongoComponent
@@ -31,6 +34,7 @@ import uk.gov.hmrc.transitmovements.services.errors.MongoError
 import uk.gov.hmrc.transitmovements.services.errors.MongoError.InsertNotAcknowledged
 import uk.gov.hmrc.transitmovements.services.errors.MongoError.UnexpectedError
 
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -52,7 +56,9 @@ class DeparturesRepositoryImpl @Inject() (
       mongoComponent = mongoComponent,
       collectionName = "departure_movements",
       domainFormat = MongoFormats.departureFormat,
-      indexes = Seq.empty,
+      indexes = Seq(
+        IndexModel(Indexes.ascending("updated"), IndexOptions().expireAfter(appConfig.documentTtl, TimeUnit.SECONDS))
+      ),
       extraCodecs = Seq(
         Codecs.playFormatCodec(MongoFormats.departureFormat)
       )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -102,6 +102,7 @@ auditing {
 mongodb {
   uri = "mongodb://localhost:27017/transit-movements"
   retryAttempts = 0
+  timeToLiveInSeconds = 2592000
 }
 
 microservice {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -102,7 +102,7 @@ auditing {
 mongodb {
   uri = "mongodb://localhost:27017/transit-movements"
   retryAttempts = 0
-  timeToLiveInSeconds = 2592000
+  timeToLiveInSeconds = 2592000 # 30 days
 }
 
 microservice {


### PR DESCRIPTION
Defaulting it to 30 days (2,592,000 seconds), pending risk assessments.