### PR TITLE
Use HolderOfTheTransitProcedure \ identificationNumber as the EORI Number

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
@@ -31,11 +31,11 @@ import java.time.format.DateTimeParseException
 object XmlParsers extends XmlParsingServiceHelpers {
 
   val movementEORINumberExtractor: Flow[ParseEvent, ParseResult[EORINumber], NotUsed] = XmlParsing
-    .subtree("CC015C" :: "messageSender" :: Nil) // TODO: see if we can get the EORI from the XSD in the future
+    .subtree("CC015C" :: "HolderOfTheTransitProcedure" :: "identificationNumber" :: Nil)
     .collect {
       case element if element.getTextContent.nonEmpty => EORINumber(element.getTextContent)
     }
-    .single("messageSender")
+    .single("identificationNumber")
 
   val preparationDateTimeExtractor: Flow[ParseEvent, ParseResult[OffsetDateTime], NotUsed] = XmlParsing
     .subtree("CC015C" :: "preparationDateAndTime" :: Nil)

--- a/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/DeparturesXmlParsingServiceSpec.scala
@@ -39,7 +39,9 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
 
   val validXml: NodeSeq =
     <CC015C>
-      <messageSender>GB1234</messageSender>
+      <HolderOfTheTransitProcedure>
+        <identificationNumber>GB1234</identificationNumber>
+      </HolderOfTheTransitProcedure>
       <preparationDateAndTime>{UTCDateString}</preparationDateAndTime>
     </CC015C>
 
@@ -50,26 +52,34 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
 
   val twoSenders: NodeSeq =
     <CC015C>
-      <messageSender>GB1234</messageSender>
-      <messageSender>XI1234</messageSender>
+      <HolderOfTheTransitProcedure>
+        <identificationNumber>GB1234</identificationNumber>
+        <identificationNumber>XI1234</identificationNumber>
+      </HolderOfTheTransitProcedure>
       <preparationDateAndTime>{UTCDateString}</preparationDateAndTime>
     </CC015C>
 
   val noDate: NodeSeq =
     <CC015C>
-      <messageSender>GB1234</messageSender>
+      <HolderOfTheTransitProcedure>
+        <identificationNumber>GB1234</identificationNumber>
+      </HolderOfTheTransitProcedure>
     </CC015C>
 
   val twoDates: NodeSeq =
     <CC015C>
-      <messageSender>GB1234</messageSender>
+      <HolderOfTheTransitProcedure>
+        <identificationNumber>GB1234</identificationNumber>
+      </HolderOfTheTransitProcedure>
       <preparationDateAndTime>{UTCDateString}</preparationDateAndTime>
       <preparationDateAndTime>{UTCDateString}</preparationDateAndTime>
     </CC015C>
 
   val badDate: NodeSeq =
     <CC015C>
-      <messageSender>GB1234</messageSender>
+      <HolderOfTheTransitProcedure>
+        <identificationNumber>GB1234</identificationNumber>
+      </HolderOfTheTransitProcedure>
       <preparationDateAndTime>notadate</preparationDateAndTime>
     </CC015C>
 
@@ -95,13 +105,13 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
       }
     }
 
-    "if it doesn't have a message sender, return ParseError.NoElementFound for the message sender" in {
+    "if it doesn't have a identificationNumber, return ParseError.NoElementFound for the message sender" in {
       val source = createStream(noSender)
 
       val result = service.extractDeclarationData(source)
 
       whenReady(result.value) {
-        _ mustBe Left(ParseError.NoElementFound("messageSender"))
+        _ mustBe Left(ParseError.NoElementFound("identificationNumber"))
       }
     }
 
@@ -115,13 +125,13 @@ class DeparturesXmlParsingServiceSpec extends AnyFreeSpec with ScalaFutures with
       }
     }
 
-    "if it has two senders, return ParseError.TooManyElementsFound" in {
+    "if it has two identificationNumbers, return ParseError.TooManyElementsFound" in {
       val source = createStream(twoSenders)
 
       val result = service.extractDeclarationData(source)
 
       whenReady(result.value) {
-        _ mustBe Left(ParseError.TooManyElementsFound("messageSender"))
+        _ mustBe Left(ParseError.TooManyElementsFound("identificationNumber"))
       }
     }
 

--- a/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
@@ -37,7 +37,9 @@ class XmlParsersSpec extends AnyFreeSpec with TestActorSystem with Matchers with
 
     val withEntry: NodeSeq =
       <CC015C>
-        <messageSender>GB1234</messageSender>
+        <HolderOfTheTransitProcedure>
+          <identificationNumber>GB1234</identificationNumber>
+        </HolderOfTheTransitProcedure>
       </CC015C>
 
     val withNoEntry: NodeSeq =
@@ -46,8 +48,10 @@ class XmlParsersSpec extends AnyFreeSpec with TestActorSystem with Matchers with
 
     val withTwoEntries: NodeSeq =
       <CC015C>
-        <messageSender>GB1234</messageSender>
-        <messageSender>XI1234</messageSender>
+        <HolderOfTheTransitProcedure>
+          <identificationNumber>GB1234</identificationNumber>
+          <identificationNumber>XI1234</identificationNumber>
+        </HolderOfTheTransitProcedure>
       </CC015C>
 
     "when provided with a valid entry" in {
@@ -64,7 +68,7 @@ class XmlParsersSpec extends AnyFreeSpec with TestActorSystem with Matchers with
       val parsedResult = stream.via(XmlParsers.movementEORINumberExtractor).runWith(Sink.head)
 
       whenReady(parsedResult) {
-        _ mustBe Left(ParseError.NoElementFound("messageSender"))
+        _ mustBe Left(ParseError.NoElementFound("identificationNumber"))
       }
     }
 
@@ -73,7 +77,7 @@ class XmlParsersSpec extends AnyFreeSpec with TestActorSystem with Matchers with
       val parsedResult = stream.via(XmlParsers.movementEORINumberExtractor).runWith(Sink.head)
 
       whenReady(parsedResult) {
-        _ mustBe Left(ParseError.TooManyElementsFound("messageSender"))
+        _ mustBe Left(ParseError.TooManyElementsFound("identificationNumber"))
       }
     }
 


### PR DESCRIPTION
As spotted in the performance test PR here: https://github.com/hmrc/ctc-traders-api-perf-tests/pull/5/commits/5c3932d5601e52de41fc8b09599ef22ca4a85834, update our transit-movements code to extract the right field.