### PR TITLE
CTCP-1921: Adding an empty movement for small messages

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/controllers/ContentTypeRouting.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/ContentTypeRouting.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v2.controllers
+package uk.gov.hmrc.transitmovements.controllers
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
@@ -25,8 +25,8 @@ import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.BaseController
 import play.api.mvc.Request
-import v2.controllers.stream.StreamingParsers
-import v2.models.errors.PresentationError
+import uk.gov.hmrc.transitmovements.controllers.errors.PresentationError
+import uk.gov.hmrc.transitmovements.controllers.stream.StreamingParsers
 
 import scala.concurrent.Future
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/ContentTypeRouting.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/ContentTypeRouting.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.http.HeaderNames
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.BaseController
+import play.api.mvc.Request
+import v2.controllers.stream.StreamingParsers
+import v2.models.errors.PresentationError
+
+import scala.concurrent.Future
+
+trait ContentTypeRouting {
+  self: BaseController with StreamingParsers =>
+
+  def contentTypeRoute(routes: PartialFunction[Option[String], Action[_]])(implicit materializer: Materializer): Action[Source[ByteString, _]] =
+    Action.async(streamFromMemory) {
+      (request: Request[Source[ByteString, _]]) =>
+        routes
+          .lift(request.headers.get(HeaderNames.CONTENT_TYPE))
+          .map(
+            action => action(request).run(request.body)
+          )
+          .getOrElse {
+            // To avoid a memory leak, we need to ensure we run the request stream and ignore it.
+            request.body.to(Sink.ignore).run()
+            Future.successful(
+              UnsupportedMediaType(
+                Json.toJson(
+                  PresentationError.unsupportedMediaTypeError(
+                    request.headers
+                      .get(HeaderNames.CONTENT_TYPE)
+                      .map(
+                        headerValue => s"Content-type header $headerValue is not supported!"
+                      )
+                      .getOrElse("A content-type header is required!")
+                  )
+                )
+              )
+            )
+          }
+    }
+
+}

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageTypeHeaderExtractor.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageTypeHeaderExtractor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
@@ -160,10 +160,7 @@ class MovementsController @Inject() (
       .asPresentation
       .fold[Result](
         baseError => Status(baseError.code.statusCode)(Json.toJson(baseError)),
-        {
-          case Some(message) => Ok(Json.toJson(message))
-          case None          => NotFound
-        }
+        movements => if (movements.isEmpty) NotFound else Ok(Json.toJson(movements))
       )
   }
 
@@ -205,10 +202,7 @@ class MovementsController @Inject() (
         .asPresentation
         .fold[Result](
           baseError => Status(baseError.code.statusCode)(Json.toJson(baseError)),
-          {
-            case Some(arrivalMessages) => Ok(Json.toJson(arrivalMessages))
-            case None                  => NotFound
-          }
+          messages => if (messages.isEmpty) NotFound else Ok(Json.toJson(messages))
         )
     }
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
@@ -113,7 +113,7 @@ class MovementsController @Inject() (
   }
 
   private def createEmptyMovement(eori: EORINumber, movementType: MovementType): Action[AnyContent] = Action.async(parse.anyContent) {
-    implicit requet =>
+    implicit request =>
       val received = OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC)
       val movement = movementFactory.createEmptyMovement(eori, movementType, received, received)
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCode.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,18 +26,20 @@ import play.api.libs.json.Writes
 sealed abstract class ErrorCode(val code: String, val statusCode: Int) extends Product with Serializable
 
 object ErrorCode {
-  case object BadRequest          extends ErrorCode("BAD_REQUEST", BAD_REQUEST)
-  case object NotFound            extends ErrorCode("NOT_FOUND", NOT_FOUND)
-  case object Forbidden           extends ErrorCode("FORBIDDEN", FORBIDDEN)
-  case object InternalServerError extends ErrorCode("INTERNAL_SERVER_ERROR", INTERNAL_SERVER_ERROR)
-  case object GatewayTimeout      extends ErrorCode("GATEWAY_TIMEOUT", GATEWAY_TIMEOUT)
+  case object BadRequest           extends ErrorCode("BAD_REQUEST", BAD_REQUEST)
+  case object NotFound             extends ErrorCode("NOT_FOUND", NOT_FOUND)
+  case object Forbidden            extends ErrorCode("FORBIDDEN", FORBIDDEN)
+  case object InternalServerError  extends ErrorCode("INTERNAL_SERVER_ERROR", INTERNAL_SERVER_ERROR)
+  case object GatewayTimeout       extends ErrorCode("GATEWAY_TIMEOUT", GATEWAY_TIMEOUT)
+  case object UnsupportedMediaType extends ErrorCode("UNSUPPORTED_MEDIA_TYPE", UNSUPPORTED_MEDIA_TYPE)
 
   lazy val errorCodes: Seq[ErrorCode] = Seq(
     BadRequest,
     NotFound,
     Forbidden,
     InternalServerError,
-    GatewayTimeout
+    GatewayTimeout,
+    UnsupportedMediaType
   )
 
   implicit val errorCodeWrites: Writes[ErrorCode] = Writes {

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/HeaderExtractError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/HeaderExtractError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/PresentationError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/PresentationError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ object PresentationError extends CommonFormats with Logging {
     logger.warn(s"Unable to parse the XML: $message")
     StandardError(message, ErrorCode.BadRequest)
   }
+
+  def unsupportedMediaTypeError(message: String): PresentationError =
+    StandardError(message, ErrorCode.UnsupportedMediaType)
 
   def notFoundError(message: String): PresentationError =
     StandardError(message, ErrorCode.NotFound)

--- a/app/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsers.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/ArrivalData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/ArrivalData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/Bindings.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/Bindings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ object Bindings {
 
     override def bind(key: String, value: String): Either[String, MovementType] =
       for {
-        urlFragment  <- binder.bind(key, value).right
-        movementType <- MovementType.movementTypes.find(_.urlFragment == urlFragment).toRight("Invalid movement type").right
+        urlFragment  <- binder.bind(key, value)
+        movementType <- MovementType.movementTypes.find(_.urlFragment == urlFragment).toRight("Invalid movement type")
       } yield movementType
 
     override def unbind(key: String, movementType: MovementType): String =

--- a/app/uk/gov/hmrc/transitmovements/models/DeclarationData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/DeclarationData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/EORINumber.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/EORINumber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/Message.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MessageData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MessageData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MessageId.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MessageId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/Movement.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/Movement.scala
@@ -24,9 +24,9 @@ case class Movement(
   _id: MovementId,
   movementType: MovementType,
   enrollmentEORINumber: EORINumber,
-  movementEORINumber: EORINumber,
+  movementEORINumber: Option[EORINumber],
   movementReferenceNumber: Option[MovementReferenceNumber], // optional pending MRN allocation
   created: OffsetDateTime,
   updated: OffsetDateTime,
-  messages: NonEmptyList[Message]
+  messages: Option[NonEmptyList[Message]]
 )

--- a/app/uk/gov/hmrc/transitmovements/models/Movement.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/Movement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.transitmovements.models
 
-import cats.data.NonEmptyList
-
 import java.time.OffsetDateTime
 
 case class Movement(
@@ -28,5 +26,5 @@ case class Movement(
   movementReferenceNumber: Option[MovementReferenceNumber], // optional pending MRN allocation
   created: OffsetDateTime,
   updated: OffsetDateTime,
-  messages: Option[NonEmptyList[Message]]
+  messages: Vector[Message]
 )

--- a/app/uk/gov/hmrc/transitmovements/models/MovementId.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MovementId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MovementReferenceNumber.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MovementReferenceNumber.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MovementType.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MovementType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/MovementWithoutMessages.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MovementWithoutMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.time.OffsetDateTime
 case class MovementWithoutMessages(
   _id: MovementId,
   enrollmentEORINumber: EORINumber,
-  movementEORINumber: EORINumber,
+  movementEORINumber: Option[EORINumber],
   movementReferenceNumber: Option[MovementReferenceNumber], // optional pending MRN allocation
   created: OffsetDateTime,
   updated: OffsetDateTime

--- a/app/uk/gov/hmrc/transitmovements/models/formats/CommonFormats.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/formats/CommonFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/formats/MongoFormats.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/formats/MongoFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/formats/PresentationFormats.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/formats/PresentationFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/responses/MessageResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/responses/MessageResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/responses/MovementResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/responses/MovementResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/responses/MovementResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/responses/MovementResponse.scala
@@ -26,4 +26,4 @@ object MovementResponse extends PresentationFormats {
   implicit val movementResponseFormat: OFormat[MovementResponse] = Json.format[MovementResponse]
 }
 
-case class MovementResponse(movementId: MovementId, messageId: MessageId)
+case class MovementResponse(movementId: MovementId, messageId: Option[MessageId])

--- a/app/uk/gov/hmrc/transitmovements/models/responses/UpdateMovementResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/responses/UpdateMovementResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/models/values/ShortUUID.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/values/ShortUUID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
+++ b/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/runtime/SystemClockModule.scala
+++ b/app/uk/gov/hmrc/transitmovements/runtime/SystemClockModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/MessageFactory.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MessageFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/MessageFactory.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MessageFactory.scala
@@ -32,7 +32,7 @@ import java.security.SecureRandom
 import java.time.Clock
 import java.time.OffsetDateTime
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -52,7 +52,8 @@ class MessageFactoryImpl @Inject() (
   clock: Clock,
   random: SecureRandom
 )(implicit
-  val materializer: Materializer
+  val materializer: Materializer,
+  ec: ExecutionContext
 ) extends MessageFactory {
 
   def create(

--- a/app/uk/gov/hmrc/transitmovements/services/MessagesXmlParsingService.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MessagesXmlParsingService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/MovementFactory.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MovementFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.transitmovements.services
 
 import akka.stream.Materializer
-import cats.data.NonEmptyList
 import com.google.inject.ImplementedBy
 import uk.gov.hmrc.transitmovements.models.values.ShortUUID
 import uk.gov.hmrc.transitmovements.models.ArrivalData
@@ -81,7 +80,7 @@ class MovementFactoryImpl @Inject() (
       movementReferenceNumber = None,
       created = created,
       updated = updated,
-      messages = NonEmptyList.one(message)
+      messages = Vector(message)
     )
 
   def createArrival(
@@ -100,7 +99,7 @@ class MovementFactoryImpl @Inject() (
       movementReferenceNumber = Some(arrivalData.mrn),
       created = created,
       updated = updated,
-      messages = NonEmptyList.one(message)
+      messages = Vector(message)
     )
 
   def createEmptyMovement(eori: EORINumber, movementType: MovementType, created: OffsetDateTime, updated: OffsetDateTime): Movement =
@@ -112,6 +111,6 @@ class MovementFactoryImpl @Inject() (
       movementReferenceNumber = None,
       created = created,
       updated = updated,
-      messages = None
+      messages = Vector.empty[Message]
     )
 }

--- a/app/uk/gov/hmrc/transitmovements/services/MovementFactory.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MovementFactory.scala
@@ -54,6 +54,8 @@ trait MovementFactory {
     updated: OffsetDateTime
   ): Movement
 
+  def createEmptyMovement(eori: EORINumber, movementType: MovementType, created: OffsetDateTime, updated: OffsetDateTime): Movement
+
 }
 
 class MovementFactoryImpl @Inject() (
@@ -75,7 +77,7 @@ class MovementFactoryImpl @Inject() (
       _id = MovementId(ShortUUID.next(clock, random)),
       enrollmentEORINumber = eori,
       movementType = movementType,
-      movementEORINumber = declarationData.movementEoriNumber,
+      movementEORINumber = Some(declarationData.movementEoriNumber),
       movementReferenceNumber = None,
       created = created,
       updated = updated,
@@ -94,11 +96,22 @@ class MovementFactoryImpl @Inject() (
       _id = MovementId(ShortUUID.next(clock, random)),
       enrollmentEORINumber = eori,
       movementType = movementType,
-      movementEORINumber = arrivalData.movementEoriNumber,
+      movementEORINumber = Some(arrivalData.movementEoriNumber),
       movementReferenceNumber = Some(arrivalData.mrn),
       created = created,
       updated = updated,
       messages = NonEmptyList.one(message)
     )
 
+  def createEmptyMovement(eori: EORINumber, movementType: MovementType, created: OffsetDateTime, updated: OffsetDateTime): Movement =
+    Movement(
+      _id = MovementId(ShortUUID.next(clock, random)),
+      enrollmentEORINumber = eori,
+      movementType = movementType,
+      movementEORINumber = None,
+      movementReferenceNumber = None,
+      created = created,
+      updated = updated,
+      messages = None
+    )
 }

--- a/app/uk/gov/hmrc/transitmovements/services/MovementsXmlParsingService.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MovementsXmlParsingService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/XmlParsers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/XmlParsingServiceHelpers.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/XmlParsingServiceHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/errors/MongoError.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/errors/MongoError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/errors/ParseError.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/errors/ParseError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/services/errors/StreamError.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/errors/StreamError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/utils/FutureConversion.scala
+++ b/app/uk/gov/hmrc/transitmovements/utils/FutureConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/utils/OrElseOnCancel.scala
+++ b/app/uk/gov/hmrc/transitmovements/utils/OrElseOnCancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/utils/PreMaterialisedFutureProvider.scala
+++ b/app/uk/gov/hmrc/transitmovements/utils/PreMaterialisedFutureProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/transitmovements/utils/StreamWithFile.scala
+++ b/app/uk/gov/hmrc/transitmovements/utils/StreamWithFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/transitmovements/it/generators/BaseGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovements/it/generators/BaseGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/transitmovements/it/generators/ModelGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovements/it/generators/ModelGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/transitmovements/it/generators/ModelGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovements/it/generators/ModelGenerators.scala
@@ -108,7 +108,7 @@ trait ModelGenerators extends BaseGenerators {
         movementReferenceNumber <- arbitrary[Option[MovementReferenceNumber]]
         created                 <- arbitrary[OffsetDateTime]
         updated                 <- arbitrary[OffsetDateTime]
-        messages                <- nonEmptyListOfMaxLength[Message](2)
-      } yield Movement(id, movementType, eori, eori, movementReferenceNumber, created, updated, messages)
+        messages                <- arbitrary[Vector[Message]]
+      } yield Movement(id, movementType, eori, Some(eori), movementReferenceNumber, created, updated, messages)
     }
 }

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -82,6 +82,26 @@ class MovementsRepositorySpec
     firstItem._id.value should be(departure._id.value)
   }
 
+  "insert" should "add an empty movement to the database" in {
+
+    lazy val emptyMovement = arbitrary[Movement].sample.value.copy(
+      _id = MovementId("2"),
+      movementEORINumber = None,
+      movementReferenceNumber = None,
+      messages = Vector.empty[Message]
+    )
+
+    await(
+      repository.insert(emptyMovement).value
+    )
+
+    val firstItem = await {
+      repository.collection.find(Filters.eq("_id", emptyMovement._id.value)).first().toFuture()
+    }
+
+    firstItem._id.value should be(emptyMovement._id.value)
+  }
+
   "getMovementWithoutMessages" should "return MovementWithoutMessages if it exists" in {
     val movement = arbitrary[Movement].sample.value
 

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -122,13 +122,10 @@ class MovementsRepositorySpec
 
   "getMessages" should "return message responses if there are messages" in {
     val messages =
-      NonEmptyList
-        .fromList(
-          List(arbitraryMessage.arbitrary.sample.value, arbitraryMessage.arbitrary.sample.value, arbitraryMessage.arbitrary.sample.value)
-            .sortBy(_.received)
-            .reverse
-        )
-        .value
+      Vector(arbitraryMessage.arbitrary.sample.value, arbitraryMessage.arbitrary.sample.value, arbitraryMessage.arbitrary.sample.value)
+        .sortBy(_.received)
+        .reverse
+
     val departure = arbitrary[Movement].sample.value.copy(messages = messages)
 
     await(repository.insert(departure).value)
@@ -145,15 +142,11 @@ class MovementsRepositorySpec
     val dateTime = arbitrary[OffsetDateTime].sample.value
 
     val messages =
-      NonEmptyList
-        .fromList(
-          List(
-            arbitraryMessage.arbitrary.sample.value.copy(received = dateTime.plusMinutes(1)),
-            arbitraryMessage.arbitrary.sample.value.copy(received = dateTime),
-            arbitraryMessage.arbitrary.sample.value.copy(received = dateTime.minusMinutes(1))
-          )
-        )
-        .value
+      Vector(
+        arbitraryMessage.arbitrary.sample.value.copy(received = dateTime.plusMinutes(1)),
+        arbitraryMessage.arbitrary.sample.value.copy(received = dateTime),
+        arbitraryMessage.arbitrary.sample.value.copy(received = dateTime.minusMinutes(1))
+      )
 
     val departure = arbitrary[Movement].sample.value.copy(messages = messages)
 
@@ -317,21 +310,21 @@ class MovementsRepositorySpec
     val departureGB1 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Departure,
         created = instant,
         updated = instant,
-        messages = NonEmptyList(message, List.empty)
+        messages = Vector(message)
       )
 
     val arrivalGB1 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Arrival,
         created = instant,
         updated = instant,
-        messages = NonEmptyList(message, List.empty)
+        messages = Vector(message)
       )
 
     val mrnGen = arbitrary[MovementReferenceNumber]
@@ -339,7 +332,7 @@ class MovementsRepositorySpec
     val departureXi1 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriXI,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         updated = instant.plusMinutes(1),
         movementReferenceNumber = mrnGen.sample
       )
@@ -347,7 +340,7 @@ class MovementsRepositorySpec
     val departureXi2 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriXI,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         updated = instant.minusMinutes(3),
         movementReferenceNumber = mrnGen.sample
       )
@@ -355,7 +348,7 @@ class MovementsRepositorySpec
     val departureGB2 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Departure,
         updated = instant.plusMinutes(1),
         movementReferenceNumber = mrnGen.sample
@@ -364,7 +357,7 @@ class MovementsRepositorySpec
     val departureGB3 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Departure,
         updated = instant.minusMinutes(3),
         movementReferenceNumber = mrnGen.sample
@@ -373,7 +366,7 @@ class MovementsRepositorySpec
     val departureGB4 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = EORINumber("1234AB"),
+        movementEORINumber = Some(EORINumber("1234AB")),
         movementType = MovementType.Departure,
         updated = instant.minusMinutes(3),
         movementReferenceNumber = mrnGen.sample
@@ -382,7 +375,7 @@ class MovementsRepositorySpec
     val arrivalGB2 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Arrival,
         updated = instant.plusMinutes(1),
         movementReferenceNumber = mrnGen.sample
@@ -391,7 +384,7 @@ class MovementsRepositorySpec
     val arrivalGB3 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = movementEORI,
+        movementEORINumber = Some(movementEORI),
         movementType = MovementType.Arrival,
         updated = instant.minusMinutes(3),
         movementReferenceNumber = mrnGen.sample
@@ -400,7 +393,7 @@ class MovementsRepositorySpec
     val arrivalGB4 =
       arbitrary[Movement].sample.value.copy(
         enrollmentEORINumber = eoriGB,
-        movementEORINumber = EORINumber("1234AB"),
+        movementEORINumber = Some(EORINumber("1234AB")),
         movementType = MovementType.Arrival,
         updated = instant.minusMinutes(3),
         movementReferenceNumber = mrnGen.sample
@@ -430,7 +423,7 @@ class MovementsRepositorySpec
           _id = departureID,
           created = instant,
           updated = instant,
-          messages = NonEmptyList(message1, List.empty)
+          messages = Vector(message1)
         )
 
     await(
@@ -474,7 +467,7 @@ class MovementsRepositorySpec
           created = instant,
           updated = instant,
           movementReferenceNumber = None,
-          messages = NonEmptyList(message1, List.empty)
+          messages = Vector(message1)
         )
 
     await(

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -100,6 +100,8 @@ class MovementsRepositorySpec
     }
 
     firstItem._id.value should be(emptyMovement._id.value)
+    firstItem.movementEORINumber should be(None)
+    firstItem.messages.isEmpty should be(true)
   }
 
   "getMovementWithoutMessages" should "return MovementWithoutMessages if it exists" in {

--- a/test/uk/gov/hmrc/transitmovements/base/SpecBase.scala
+++ b/test/uk/gov/hmrc/transitmovements/base/SpecBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/base/StreamTestHelpers.scala
+++ b/test/uk/gov/hmrc/transitmovements/base/StreamTestHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/base/TestActorSystem.scala
+++ b/test/uk/gov/hmrc/transitmovements/base/TestActorSystem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/base/TestSourceProvider.scala
+++ b/test/uk/gov/hmrc/transitmovements/base/TestSourceProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageTypeHeaderExtractorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageTypeHeaderExtractorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -56,6 +56,7 @@ import uk.gov.hmrc.transitmovements.controllers.errors.HeaderExtractError.Invali
 import uk.gov.hmrc.transitmovements.controllers.errors.HeaderExtractError.NoHeaderFound
 import uk.gov.hmrc.transitmovements.fakes.utils.FakePreMaterialisedFutureProvider
 import uk.gov.hmrc.transitmovements.generators.ModelGenerators
+import uk.gov.hmrc.transitmovements.models.ArrivalData
 import uk.gov.hmrc.transitmovements.models.DeclarationData
 import uk.gov.hmrc.transitmovements.models.EORINumber
 import uk.gov.hmrc.transitmovements.models.Message
@@ -75,7 +76,6 @@ import uk.gov.hmrc.transitmovements.services.MessagesXmlParsingService
 import uk.gov.hmrc.transitmovements.services.MovementFactory
 import uk.gov.hmrc.transitmovements.services.MovementsXmlParsingService
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
-import uk.gov.hmrc.transitmovements.services.errors.MongoError.InsertNotAcknowledged
 import uk.gov.hmrc.transitmovements.services.errors.MongoError.UnexpectedError
 import uk.gov.hmrc.transitmovements.services.errors.ParseError
 import uk.gov.hmrc.transitmovements.services.errors.StreamError
@@ -566,6 +566,192 @@ class MovementsControllerSpec
 
         val result =
           controller.createMovement(eoriNumber, MovementType.Departure)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+        contentAsJson(result) mustBe Json.obj(
+          "code"    -> "INTERNAL_SERVER_ERROR",
+          "message" -> "Internal server error"
+        )
+      }
+    }
+  }
+  "createMovement - Arrival" - {
+
+    val validXml: NodeSeq =
+      <CC007C>
+        <messageSender>ABC123</messageSender>
+        <preparationDateAndTime>2022-05-25T09:37:04</preparationDateAndTime>
+        <TraderAtDestination>
+          <identificationNumber>eori</identificationNumber>
+        </TraderAtDestination>
+        <TransitOperation>
+          <MRN>movement reerence number</MRN>
+        </TransitOperation>
+      </CC007C>
+
+    lazy val arrivalData = ArrivalData(eoriNumber, OffsetDateTime.now(ZoneId.of("UTC")), mrn)
+
+    lazy val arrivalDataEither: EitherT[Future, ParseError, ArrivalData] =
+      EitherT.rightT(arrivalData)
+
+    "must return OK if XML data extraction is successful" in {
+
+      val tempFile = SingletonTemporaryFileCreator.create()
+      when(mockTemporaryFileCreator.create()).thenReturn(tempFile)
+
+      when(mockMovementsXmlParsingService.extractArrivalData(any[Source[ByteString, _]]))
+        .thenReturn(arrivalDataEither)
+
+      when(
+        mockMovementFactory.createArrival(
+          any[String].asInstanceOf[EORINumber],
+          any[String].asInstanceOf[MovementType],
+          any[ArrivalData],
+          any[Message],
+          any[OffsetDateTime],
+          any[OffsetDateTime]
+        )
+      )
+        .thenReturn(movement)
+
+      when(
+        mockMessageFactory.create(any[MessageType], any[OffsetDateTime], any[OffsetDateTime], any[Option[MessageId]], any[Source[ByteString, Future[IOResult]]])
+      )
+        .thenReturn(messageFactoryEither)
+
+      when(mockRepository.insert(any()))
+        .thenReturn(EitherT.rightT(Right(())))
+
+      val request = fakeRequest(POST, validXml, Some(MessageType.ArrivalNotification.code))
+
+      val result =
+        controller.createMovement(eoriNumber, MovementType.Arrival)(request)
+
+      status(result) mustBe OK
+      contentAsJson(result) mustBe Json.obj(
+        "movementId" -> movementId.value,
+        "messageId"  -> messageId.value
+      )
+    }
+
+    "must return BAD_REQUEST when XML data extraction fails" - {
+
+      "contains message to indicate element not found" in {
+
+        val elementNotFoundXml: NodeSeq =
+          <CC007C></CC007C>
+
+        when(mockMovementsXmlParsingService.extractArrivalData(any[Source[ByteString, _]]))
+          .thenReturn(EitherT.leftT(ParseError.NoElementFound("messageSender")))
+
+        when(mockTemporaryFileCreator.create()).thenReturn(SingletonTemporaryFileCreator.create())
+
+        val request = fakeRequest(POST, elementNotFoundXml, Some(MessageType.ArrivalNotification.code))
+
+        val result =
+          controller.createMovement(eoriNumber, MovementType.Arrival)(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"    -> "BAD_REQUEST",
+          "message" -> "Element messageSender not found"
+        )
+      }
+
+      "contains message to indicate too many elements found" in {
+
+        val tooManyFoundXml: NodeSeq =
+          <CC007C>
+            <messageSender>GB1234</messageSender>
+            <messageSender>XI1234</messageSender>
+          </CC007C>
+
+        when(mockMovementsXmlParsingService.extractArrivalData(any[Source[ByteString, _]]))
+          .thenReturn(EitherT.leftT(ParseError.TooManyElementsFound("messageSender")))
+
+        when(mockTemporaryFileCreator.create()).thenReturn(SingletonTemporaryFileCreator.create())
+
+        val request = fakeRequest(POST, tooManyFoundXml, Some(MessageType.ArrivalNotification.code))
+
+        val result =
+          controller.createMovement(eoriNumber, MovementType.Arrival)(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"    -> "BAD_REQUEST",
+          "message" -> "Found too many elements of type messageSender"
+        )
+      }
+
+      "contains message to indicate date time failure" in {
+
+        val tooManyFoundXml: NodeSeq =
+          <CC007C>
+            <messageSender>GB1234</messageSender>
+            <preparationDateAndTime>no</preparationDateAndTime>
+          </CC007C>
+
+        val cs: CharSequence = "no"
+
+        when(mockMovementsXmlParsingService.extractArrivalData(any[Source[ByteString, _]]))
+          .thenReturn(
+            EitherT.leftT(
+              ParseError.BadDateTime("preparationDateAndTime", new DateTimeParseException("Text 'no' could not be parsed at index 0", cs, 0))
+            )
+          )
+
+        when(mockTemporaryFileCreator.create()).thenReturn(SingletonTemporaryFileCreator.create())
+
+        val request = fakeRequest(POST, tooManyFoundXml, Some(MessageType.ArrivalNotification.code))
+
+        val result =
+          controller.createMovement(eoriNumber, MovementType.Arrival)(request)
+
+        status(result) mustBe BAD_REQUEST
+        contentAsJson(result) mustBe Json.obj(
+          "code"    -> "BAD_REQUEST",
+          "message" -> "Could not parse datetime for preparationDateAndTime: Text 'no' could not be parsed at index 0"
+        )
+      }
+    }
+
+    "must return INTERNAL_SERVICE_ERROR" - {
+
+      "when an invalid xml causes an unknown ParseError to be thrown" in {
+
+        val unknownErrorXml: String =
+          "<CC007C><messageSender>GB1234</messageSender>"
+
+        when(mockMovementsXmlParsingService.extractArrivalData(any[Source[ByteString, _]]))
+          .thenReturn(EitherT.leftT(ParseError.UnexpectedError(Some(new IllegalArgumentException()))))
+
+        when(mockTemporaryFileCreator.create()).thenReturn(SingletonTemporaryFileCreator.create())
+
+        val request = FakeRequest(
+          method = POST,
+          uri = routes.MovementsController.createMovement(eoriNumber, MovementType.Arrival).url,
+          headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.XML, "X-Message-Type" -> MessageType.ArrivalNotification.code)),
+          body = unknownErrorXml
+        )
+
+        val result =
+          controller.createMovement(eoriNumber, MovementType.Arrival)(request)
+
+        //status(result) mustBe INTERNAL_SERVER_ERROR
+        contentAsJson(result) mustBe Json.obj(
+          "code"    -> "INTERNAL_SERVER_ERROR",
+          "message" -> "Internal server error"
+        )
+      }
+
+      "when file creation fails" in {
+
+        when(mockTemporaryFileCreator.create()).thenThrow(new Exception("File creation failed"))
+
+        val request = fakeRequest(POST, validXml, Some(MessageType.ArrivalNotification.code))
+
+        val result =
+          controller.createMovement(eoriNumber, MovementType.Arrival)(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
         contentAsJson(result) mustBe Json.obj(

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,10 +112,10 @@ class MovementsControllerSpec
   lazy val movement = arbitrary[Movement].sample.value.copy(
     _id = movementId,
     enrollmentEORINumber = eoriNumber,
-    movementEORINumber = eoriNumber,
+    movementEORINumber = Some(eoriNumber),
     created = now,
     updated = now,
-    messages = NonEmptyList.one(message)
+    messages = Vector(message)
   )
 
   val now = OffsetDateTime.now

--- a/test/uk/gov/hmrc/transitmovements/controllers/errors/ConvertErrorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/errors/ConvertErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCodeSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/controllers/errors/PresentationErrorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/errors/PresentationErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ class PresentationErrorSpec extends AnyFreeSpec with Matchers with MockitoSugar 
     "for BadRequest" in testStandard(PresentationError.badRequestError, "bad request", "BAD_REQUEST")
 
     "for NotFound" in testStandard(PresentationError.notFoundError, "not found", "NOT_FOUND")
+
+    "for UnsupportedMediaType" in testStandard(PresentationError.unsupportedMediaTypeError, "unsupported media type", "UNSUPPORTED_MEDIA_TYPE")
 
     Seq(Some(new IllegalStateException("message")), None).foreach {
       exception =>

--- a/test/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsersSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/fakes/utils/FakePreMaterialisedFutureProvider.scala
+++ b/test/uk/gov/hmrc/transitmovements/fakes/utils/FakePreMaterialisedFutureProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/generators/BaseGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovements/generators/BaseGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,8 +105,8 @@ trait ModelGenerators extends BaseGenerators {
         movementReferenceNumber <- arbitrary[Option[MovementReferenceNumber]]
         created                 <- arbitrary[OffsetDateTime]
         updated                 <- arbitrary[OffsetDateTime]
-        messages                <- nonEmptyListOfMaxLength[Message](2)
-      } yield Movement(id, movementType, eori, eori, movementReferenceNumber, created, updated, messages)
+        messages                <- arbitrary[Vector[Message]]
+      } yield Movement(id, movementType, eori, Some(eori), movementReferenceNumber, created, updated, messages)
     }
 
   implicit lazy val arbitraryMessageResponse: Arbitrary[MessageResponse] =

--- a/test/uk/gov/hmrc/transitmovements/models/MovementSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/models/MovementSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.transitmovements.models
 
-import cats.data.NonEmptyList
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsString
@@ -34,11 +33,11 @@ class MovementSpec extends AnyFlatSpec with Matchers with PresentationFormats {
       MovementId("1"),
       MovementType.Departure,
       EORINumber("222"),
-      EORINumber("223"),
+      Some(EORINumber("223")),
       Some(MovementReferenceNumber("333")),
       OffsetDateTime.now(),
       OffsetDateTime.now(),
-      NonEmptyList.one(
+      Vector(
         Message(
           id = MessageId("999"),
           received = OffsetDateTime.now(),
@@ -55,6 +54,7 @@ class MovementSpec extends AnyFlatSpec with Matchers with PresentationFormats {
 
     (result \ "_id").get should be(JsString("1"))
     (result \ "movementEORINumber").get should be(JsString("223"))
-    (result \ "movementReferenceNumber").get should be(JsString("333"))
+    (result \ "movementEORINumber").get should be(JsString("223"))
+    (result \ "messages" \\ "id").head should be(JsString("999"))
   }
 }

--- a/test/uk/gov/hmrc/transitmovements/models/formats/CommonFormatsSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/models/formats/CommonFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/models/formats/MongoFormatsSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/models/formats/MongoFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/models/values/ShortUUIDSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/models/values/ShortUUIDSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/services/MessageFactoryImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MessageFactoryImplSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/services/MessageFactoryImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MessageFactoryImplSpec.scala
@@ -43,7 +43,7 @@ class MessageFactoryImplSpec extends SpecBase with ScalaFutures with Matchers wi
 
     val tempFile = SingletonTemporaryFileCreator.create()
 
-    val sut = new MessageFactoryImpl(clock, random)
+    val sut = new MessageFactoryImpl(clock, random)(materializer, materializer.executionContext)
 
     "will create a message with a body when given a stream" in {
       val stream    = FileIO.fromPath(tempFile.path)

--- a/test/uk/gov/hmrc/transitmovements/services/MessageXmlParsingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MessageXmlParsingServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
@@ -80,4 +80,23 @@ class MovementFactoryImplSpec
         arrival.messages.head mustBe message
     }
   }
+
+  "createEmptyMovement" - {
+    val sut = new MovementFactoryImpl(clock, random)
+
+    "will create a movement without a message, movementEORINumber and movementReferenceNumber" in forAll(
+      arbitrary[MovementType],
+      arbitrary[EORINumber]
+    ) {
+      (movementType, enrollmentEori) =>
+        val movement =
+          sut.createEmptyMovement(enrollmentEori, movementType, instant, instant)
+
+        movement.movementType mustBe movementType
+        movement.messages.length mustBe 0
+        movement.movementReferenceNumber mustBe None
+        movement.enrollmentEORINumber mustBe enrollmentEori
+        movement.movementEORINumber mustBe None
+    }
+  }
 }

--- a/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,10 @@ class MovementFactoryImplSpec
         val departure =
           sut.createDeparture(enrollmentEori, MovementType.Departure, DeclarationData(movementEori, instant), message, instant, instant)
 
-        departure.messages.length mustBe 1
+        departure.messages.get.length mustBe 1
         departure.movementReferenceNumber mustBe None
         departure.enrollmentEORINumber mustBe enrollmentEori
-        departure.movementEORINumber mustBe movementEori
+        departure.movementEORINumber mustBe Some(movementEori)
         departure.messages.head mustBe message
     }
   }
@@ -73,10 +73,10 @@ class MovementFactoryImplSpec
         val arrival =
           sut.createArrival(enrollmentEori, MovementType.Arrival, ArrivalData(movementEori, instant, mrn), message, instant, instant)
 
-        arrival.messages.length mustBe 1
+        arrival.messages.get.length mustBe 1
         arrival.movementReferenceNumber mustBe Some(mrn)
         arrival.enrollmentEORINumber mustBe enrollmentEori
-        arrival.movementEORINumber mustBe movementEori
+        arrival.movementEORINumber mustBe Some(movementEori)
         arrival.messages.head mustBe message
     }
   }

--- a/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MovementFactoryImplSpec.scala
@@ -57,7 +57,7 @@ class MovementFactoryImplSpec
         val departure =
           sut.createDeparture(enrollmentEori, MovementType.Departure, DeclarationData(movementEori, instant), message, instant, instant)
 
-        departure.messages.get.length mustBe 1
+        departure.messages.length mustBe 1
         departure.movementReferenceNumber mustBe None
         departure.enrollmentEORINumber mustBe enrollmentEori
         departure.movementEORINumber mustBe Some(movementEori)
@@ -73,7 +73,7 @@ class MovementFactoryImplSpec
         val arrival =
           sut.createArrival(enrollmentEori, MovementType.Arrival, ArrivalData(movementEori, instant, mrn), message, instant, instant)
 
-        arrival.messages.get.length mustBe 1
+        arrival.messages.length mustBe 1
         arrival.movementReferenceNumber mustBe Some(mrn)
         arrival.enrollmentEORINumber mustBe enrollmentEori
         arrival.movementEORINumber mustBe Some(movementEori)

--- a/test/uk/gov/hmrc/transitmovements/services/MovementsXmlParsingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MovementsXmlParsingServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/XmlParsersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/utils/FutureConversionSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/utils/FutureConversionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/utils/PreMaterialisedFutureProviderSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/utils/PreMaterialisedFutureProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This has been implemented in respect to the following conclusions derived in a discussion between devs and QAs:

- We'll make messageId optional for the create a movement endpoint.

- We're going to check for the content-type header and if it's not present, assume it's a large message. We will need to ensure the API always sends the content-type for small messages.

- We're going to make the messages object in the Movement a List, there's no difference logically between List and Option[NonEmptyList] so there's no need to overcomplicate things. I have decided to use a Vector instead as it's more efficient than a List.