### PR TITLE
CTCP-2571: Add Object Store controller/route for rationalisation of object store access code

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/config/Constants.scala
+++ b/app/uk/gov/hmrc/transitmovements/config/Constants.scala
@@ -21,4 +21,6 @@ object Constants {
   val ObjectStoreURI = "X-Object-Store-Uri"
   val MessageType    = "X-Message-Type"
 
+  val ObjectStoreOwner = "common-transit-convention-traders"
+
 }

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.transitmovements.controllers
 
-import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import cats.data.EitherT
 import play.api.Logging
+import play.api.http.MimeTypes
 import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
@@ -21,15 +37,15 @@ import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
 import uk.gov.hmrc.transitmovements.services.ObjectStoreService
-import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
 
-import java.net.URI
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class MessageBodyController(cc: ControllerComponents,
-                            repo: MovementsRepository,
-                            objectStoreService: ObjectStoreService)(implicit mat: Materializer, ec: ExecutionContext) extends BackendController(cc) with Logging with ConvertError with ObjectStoreURIHelpers {
+class MessageBodyController(cc: ControllerComponents, repo: MovementsRepository, objectStoreService: ObjectStoreService)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with Logging
+    with ConvertError
+    with ObjectStoreURIHelpers {
 
   def getBody(eori: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[AnyContent] = Action.async {
     implicit request =>
@@ -37,24 +53,33 @@ class MessageBodyController(cc: ControllerComponents,
         maybeMessage <- repo.getSingleMessage(eori, movementId, messageId, movementType).asPresentation
         message      <- ensureMessage(maybeMessage, messageId, movementId)
         stream       <- body(message, messageId, movementId)
-      } yield Ok.chunked(stream))
-        .valueOrF(error => Future.successful(Status(error.code.statusCode)(Json.toJson(error))))
+      } yield Ok.chunked(stream, Some(MimeTypes.XML)))
+        .valueOrF(
+          error => Future.successful(Status(error.code.statusCode)(Json.toJson(error)))
+        )
   }
 
-  private def ensureMessage(message: Option[MessageResponse], messageId: MessageId, movementId: MovementId): EitherT[Future, PresentationError, MessageResponse] =
+  private def ensureMessage(
+    message: Option[MessageResponse],
+    messageId: MessageId,
+    movementId: MovementId
+  ): EitherT[Future, PresentationError, MessageResponse] =
     message.map(EitherT.rightT[Future, PresentationError](_)).getOrElse(notFound(messageId, movementId))
 
-  private def body(messageResponse: MessageResponse, messageId: MessageId, movementId: MovementId)(implicit hc: HeaderCarrier): EitherT[Future, PresentationError, Source[ByteString, _]] = {
+  private def body(messageResponse: MessageResponse, messageId: MessageId, movementId: MovementId)(implicit
+    hc: HeaderCarrier
+  ): EitherT[Future, PresentationError, Source[ByteString, _]] =
     messageResponse match {
       case MessageResponse(_, _, _, Some(body), _, _) => EitherT.rightT(Source.single(ByteString(body)))
       case MessageResponse(_, _, _, None, _, Some(uri)) =>
         for {
           resourceLocation <- extractResourceLocation(ObjectStoreURI(uri.toString))
-          source           <- objectStoreService.getObjectStoreFile(resourceLocation).asPresentation
+          source <- objectStoreService
+            .getObjectStoreFile(resourceLocation)
+            .asPresentation(objectStoreErrorWithInternalServiceErrorConverter, implicitly[ExecutionContext])
         } yield source
       case _ => notFound(messageId, movementId)
     }
-  }
 
   private def notFound[A](messageId: MessageId, movementId: MovementId): EitherT[Future, PresentationError, A] =
     EitherT.leftT(PresentationError.notFoundError(s"Body of message ID ${messageId.value} for movement ID ${movementId.value} was not found"))

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -1,0 +1,61 @@
+package uk.gov.hmrc.transitmovements.controllers
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import play.api.Logging
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.transitmovements.controllers.errors.ConvertError
+import uk.gov.hmrc.transitmovements.controllers.errors.PresentationError
+import uk.gov.hmrc.transitmovements.models.EORINumber
+import uk.gov.hmrc.transitmovements.models.MessageId
+import uk.gov.hmrc.transitmovements.models.MovementId
+import uk.gov.hmrc.transitmovements.models.MovementType
+import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
+import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
+import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
+import uk.gov.hmrc.transitmovements.services.ObjectStoreService
+import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
+
+import java.net.URI
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class MessageBodyController(cc: ControllerComponents,
+                            repo: MovementsRepository,
+                            objectStoreService: ObjectStoreService)(implicit mat: Materializer, ec: ExecutionContext) extends BackendController(cc) with Logging with ConvertError with ObjectStoreURIHelpers {
+
+  def getBody(eori: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[AnyContent] = Action.async {
+    implicit request =>
+      (for {
+        maybeMessage <- repo.getSingleMessage(eori, movementId, messageId, movementType).asPresentation
+        message      <- ensureMessage(maybeMessage, messageId, movementId)
+        stream       <- body(message, messageId, movementId)
+      } yield Ok.chunked(stream))
+        .valueOrF(error => Future.successful(Status(error.code.statusCode)(Json.toJson(error))))
+  }
+
+  private def ensureMessage(message: Option[MessageResponse], messageId: MessageId, movementId: MovementId): EitherT[Future, PresentationError, MessageResponse] =
+    message.map(EitherT.rightT[Future, PresentationError](_)).getOrElse(notFound(messageId, movementId))
+
+  private def body(messageResponse: MessageResponse, messageId: MessageId, movementId: MovementId)(implicit hc: HeaderCarrier): EitherT[Future, PresentationError, Source[ByteString, _]] = {
+    messageResponse match {
+      case MessageResponse(_, _, _, Some(body), _, _) => EitherT.rightT(Source.single(ByteString(body)))
+      case MessageResponse(_, _, _, None, _, Some(uri)) =>
+        for {
+          resourceLocation <- extractResourceLocation(ObjectStoreURI(uri.toString))
+          source           <- objectStoreService.getObjectStoreFile(resourceLocation).asPresentation
+        } yield source
+      case _ => notFound(messageId, movementId)
+    }
+  }
+
+  private def notFound[A](messageId: MessageId, movementId: MovementId): EitherT[Future, PresentationError, A] =
+    EitherT.leftT(PresentationError.notFoundError(s"Body of message ID ${messageId.value} for movement ID ${movementId.value} was not found"))
+}

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -38,11 +38,13 @@ import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
 import uk.gov.hmrc.transitmovements.services.ObjectStoreService
 
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class MessageBodyController(cc: ControllerComponents, repo: MovementsRepository, objectStoreService: ObjectStoreService)(implicit ec: ExecutionContext)
-    extends BackendController(cc)
+class MessageBodyController @Inject() (cc: ControllerComponents, repo: MovementsRepository, objectStoreService: ObjectStoreService)(implicit
+  ec: ExecutionContext
+) extends BackendController(cc)
     with Logging
     with ConvertError
     with ObjectStoreURIHelpers {

--- a/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
@@ -116,7 +116,7 @@ class MovementsController @Inject() (
       received   = OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC)
       movementId = movementFactory.generateId()
       messageId  = messageFactory.generateId()
-      objectSummary <- objectStoreService.addMessage(movementId, messageId, request.body).asPresentation
+      objectSummary <- objectStoreService.putObjectStoreFile(movementId, messageId, request.body).asPresentation
       message = messageFactory
         .createSmallMessage(
           messageId,
@@ -163,7 +163,7 @@ class MovementsController @Inject() (
       received   = OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC)
       movementId = movementFactory.generateId()
       messageId  = messageFactory.generateId()
-      objectSummary <- objectStoreService.addMessage(movementId, messageId, request.body).asPresentation
+      objectSummary <- objectStoreService.putObjectStoreFile(movementId, messageId, request.body).asPresentation
       message = messageFactory
         .createSmallMessage(
           messageId,
@@ -284,7 +284,7 @@ class MovementsController @Inject() (
       messageData <- messagesXmlParsingService.extractMessageData(request.body, messageType).asPresentation //request.body
       received  = OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC)
       messageId = messageFactory.generateId()
-      objectSummary <- objectStoreService.addMessage(movementId, messageId, request.body).asPresentation
+      objectSummary <- objectStoreService.putObjectStoreFile(movementId, messageId, request.body).asPresentation
       status = if (MessageType.responseValues.exists(_.code == messageType.code)) MessageStatus.Received else MessageStatus.Processing
       message = messageFactory
         .createSmallMessage(

--- a/app/uk/gov/hmrc/transitmovements/controllers/ObjectStoreController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/ObjectStoreController.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.controllers
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.google.inject.Inject
+import play.api.Logging
+import play.api.http.MimeTypes
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.transitmovements.controllers.errors.ConvertError
+import uk.gov.hmrc.transitmovements.controllers.stream.StreamingParsers
+import uk.gov.hmrc.transitmovements.models.MessageId
+import uk.gov.hmrc.transitmovements.models.MovementId
+import uk.gov.hmrc.transitmovements.models.ObjectStoreSummaryResponse
+import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
+import uk.gov.hmrc.transitmovements.services.ObjectStoreService
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+// Temporary until we can remove the passing of Object Store URIs about
+class ObjectStoreController @Inject() (cc: ControllerComponents, objectStoreService: ObjectStoreService)(implicit
+  val materializer: Materializer,
+  ec: ExecutionContext
+) extends BackendController(cc)
+    with ObjectStoreURIHelpers
+    with ConvertError
+    with StreamingParsers
+    with Logging {
+
+  def getObject(uri: ObjectStoreURI): Action[AnyContent] = Action.async {
+    implicit request =>
+      (for {
+        resourceLocation <- extractResourceLocation(uri)
+        objectStream <- objectStoreService
+          .getObjectStoreFile(resourceLocation)
+          .asPresentation(objectStoreErrorWithNotFoundConverter, implicitly[ExecutionContext])
+      } yield Ok.chunked(objectStream, Some(MimeTypes.XML)))
+        .valueOrF(
+          error => Future.successful(Status(error.code.statusCode)(Json.toJson(error)))
+        )
+  }
+
+  def putObject(movementId: MovementId, messageId: MessageId): Action[Source[ByteString, _]] = Action.async(streamFromMemory) {
+    implicit request =>
+      objectStoreService
+        .putObjectStoreFile(movementId, messageId, request.body)
+        .map(
+          summary => ObjectStoreSummaryResponse(summary)
+        )
+        .asPresentation
+        .fold(
+          error => Status(error.code.statusCode)(Json.toJson(error)),
+          result => Created(Json.toJson(result))
+        )
+  }
+
+}

--- a/app/uk/gov/hmrc/transitmovements/controllers/ObjectStoreURIHelpers.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/ObjectStoreURIHelpers.scala
@@ -40,7 +40,7 @@ trait ObjectStoreURIHelpers {
     EitherT {
       Future.successful(
         objectStoreURI.asResourceLocation
-          .toRight(PresentationError.badRequestError(s"Provided Object Store URI is not owned by ${ObjectStoreURI.expectedOwner}"))
+          .toRight(PresentationError.badRequestError(s"Provided Object Store URI is not owned by ${Constants.ObjectStoreOwner}"))
       )
     }
 }

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -93,7 +93,7 @@ trait ConvertError {
 
     override def convert(input: ObjectStoreError): PresentationError = input match {
       case FileNotFound(fileLocation) => PresentationError.internalServiceError(s"file not found at location: $fileLocation", cause = None)
-      case x                          => objectStoreErrorConverter.convert(x)
+      case err                        => objectStoreErrorConverter.convert(err)
     }
   }
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -84,7 +84,7 @@ trait ConvertError {
 
     override def convert(input: ObjectStoreError): PresentationError = input match {
       case FileNotFound(fileLocation) => PresentationError.notFoundError(s"file not found at location: $fileLocation")
-      case x => objectStoreErrorConverter.convert(x)
+      case x                          => objectStoreErrorConverter.convert(x)
     }
   }
 
@@ -93,7 +93,7 @@ trait ConvertError {
 
     override def convert(input: ObjectStoreError): PresentationError = input match {
       case FileNotFound(fileLocation) => PresentationError.internalServiceError(s"file not found at location: $fileLocation", cause = None)
-      case x => objectStoreErrorConverter.convert(x)
+      case x                          => objectStoreErrorConverter.convert(x)
     }
   }
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -88,6 +88,15 @@ trait ConvertError {
     }
   }
 
+  // Needed for the message body controller
+  val objectStoreErrorWithInternalServiceErrorConverter = new Converter[ObjectStoreError] {
+
+    override def convert(input: ObjectStoreError): PresentationError = input match {
+      case FileNotFound(fileLocation) => PresentationError.internalServiceError(s"file not found at location: $fileLocation", cause = None)
+      case x => objectStoreErrorConverter.convert(x)
+    }
+  }
+
   implicit val messageTypeExtractErrorConverter = new Converter[MessageTypeExtractError] {
     import uk.gov.hmrc.transitmovements.controllers.errors.MessageTypeExtractError._
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.transitmovements.controllers.errors
 import cats.data.EitherT
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
 import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
+import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError.FileNotFound
 import uk.gov.hmrc.transitmovements.services.errors.ParseError
 import uk.gov.hmrc.transitmovements.services.errors.StreamError
 
@@ -75,6 +76,15 @@ trait ConvertError {
     def convert(objectStoreError: ObjectStoreError): PresentationError = objectStoreError match {
       case FileNotFound(fileLocation) => PresentationError.badRequestError(s"file not found at location: $fileLocation")
       case UnexpectedError(ex)        => PresentationError.internalServiceError(cause = ex)
+    }
+  }
+
+  // Needed for the object store controller (pass by URL instead of header).
+  val objectStoreErrorWithNotFoundConverter = new Converter[ObjectStoreError] {
+
+    override def convert(input: ObjectStoreError): PresentationError = input match {
+      case FileNotFound(fileLocation) => PresentationError.notFoundError(s"file not found at location: $fileLocation")
+      case x => objectStoreErrorConverter.convert(x)
     }
   }
 

--- a/app/uk/gov/hmrc/transitmovements/models/ObjectStoreURI.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/ObjectStoreURI.scala
@@ -18,17 +18,17 @@ package uk.gov.hmrc.transitmovements.models
 
 import play.api.libs.json.Format
 import play.api.libs.json.Json
+import uk.gov.hmrc.transitmovements.config.Constants
 
 import scala.util.matching.Regex
 
 object ObjectStoreURI {
-  val expectedOwner = "common-transit-convention-traders"
 
   // The URI consists of the service name in the first part of the path, followed
   // by the location of the object in the context of that service. As this service
   // targets common-transit-convention-traders' objects exclusively, we ensure
   // the URI is targeting that context. This regex ensures that this is the case.
-  lazy val expectedUriPattern: Regex = s"^$expectedOwner/(.+)$$".r
+  lazy val expectedUriPattern: Regex = s"^${Constants.ObjectStoreOwner}/(.+)$$".r
 
   implicit val objectStoreURIformat: Format[ObjectStoreURI] = Json.valueFormat[ObjectStoreURI]
 }

--- a/app/uk/gov/hmrc/transitmovements/models/ObjectSummaryResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/ObjectSummaryResponse.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.models
+
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
+
+import java.time.Instant
+
+object ObjectStoreSummaryResponse {
+  implicit lazy val format: OFormat[ObjectStoreSummaryResponse] = Json.format[ObjectStoreSummaryResponse]
+
+  def apply(objectStoreSummary: ObjectSummaryWithMd5): ObjectStoreSummaryResponse =
+    ObjectStoreSummaryResponse(
+      objectStoreSummary.location.asUri,
+      objectStoreSummary.contentLength,
+      objectStoreSummary.contentMd5.value,
+      objectStoreSummary.lastModified
+    )
+}
+
+case class ObjectStoreSummaryResponse(
+  location: String,
+  contentLength: Long,
+  contentMd5: String,
+  lastModified: Instant
+)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,6 +14,10 @@ PATCH      /traders/:EORI/movements/:movementType/:movementId/messages/:messageI
 
 POST       /traders/movements/:movementId/messages                                 uk.gov.hmrc.transitmovements.controllers.MovementsController.updateMovement(movementId: MovementId, triggerId: Option[MessageId] ?= None)
 
+# -- Message Body
+
+GET        /traders/:EORI/movements/:movementType/:movementId/messages/:messageId/body uk.gov.hmrc.transitmovements.controllers.MessageBodyController.getBody(EORI: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId)
+
 # -- Object Store facade -- to be removed when proper refactoring is completed.
 
 GET        /object/*location                                                        uk.gov.hmrc.transitmovements.controllers.ObjectStoreController.getObject(location: ObjectStoreURI)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,4 +14,8 @@ PATCH      /traders/:EORI/movements/:movementType/:movementId/messages/:messageI
 
 POST       /traders/movements/:movementId/messages                                 uk.gov.hmrc.transitmovements.controllers.MovementsController.updateMovement(movementId: MovementId, triggerId: Option[MessageId] ?= None)
 
+# -- Object Store facade -- to be removed when proper refactoring is completed.
 
+GET        /object/*location                                                        uk.gov.hmrc.transitmovements.controllers.ObjectStoreController.getObject(location: ObjectStoreURI)
+
+PUT        /object/movement/:movementId/message/:messageId                          uk.gov.hmrc.transitmovements.controllers.ObjectStoreController.putObject(movementId: MovementId, messageId: MessageId)

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -461,8 +461,7 @@ class MovementsRepositorySpec
         movementReferenceNumber = mrnGen.sample
       )
 
-    def setup() {
-
+    def setup() = {
       //populate db in non-time order
       await(repository.insert(departureXi2).value)
       await(repository.insert(departureGB2).value)
@@ -744,9 +743,6 @@ class MovementsRepositorySpec
     arbitrary[MovementReferenceNumber]
   ) {
     (movementId, eori, mrn) =>
-      val message =
-        arbitrary[Message].sample.value.copy(body = None, messageType = MessageType.DepartureOfficeRejection, triggerId = Some(MessageId(movementId.value)))
-
       val result = await(
         repository.updateMovement(movementId, Some(eori), Some(mrn), instant).value
       )

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.controllers
+
+import akka.stream.IOResult
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import akka.util.Timeout
+import cats.data.EitherT
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.MockitoSugar.reset
+import org.mockito.MockitoSugar.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.OK
+import play.api.libs.Files.SingletonTemporaryFileCreator
+import play.api.libs.Files.TemporaryFileCreator
+import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsEmpty
+import play.api.mvc.Request
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers.contentAsJson
+import play.api.test.Helpers.status
+import play.api.test.Helpers.stubControllerComponents
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpVerbs.POST
+import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.transitmovements.base.SpecBase
+import uk.gov.hmrc.transitmovements.base.TestActorSystem
+import uk.gov.hmrc.transitmovements.config.AppConfig
+import uk.gov.hmrc.transitmovements.generators.ModelGenerators
+import uk.gov.hmrc.transitmovements.models._
+import uk.gov.hmrc.transitmovements.models.formats.PresentationFormats
+import uk.gov.hmrc.transitmovements.models.requests
+import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
+import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
+import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
+import uk.gov.hmrc.transitmovements.services._
+import uk.gov.hmrc.transitmovements.services.errors.MongoError
+import uk.gov.hmrc.transitmovements.services.errors.MongoError.UnexpectedError
+import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
+import uk.gov.hmrc.transitmovements.services.errors.ParseError
+import uk.gov.hmrc.transitmovements.services.errors.StreamError
+
+import java.net.URI
+import java.security.SecureRandom
+import java.time.Clock
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
+import java.util.UUID.randomUUID
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.xml.NodeSeq
+
+class MessageBodyControllerSpec
+    extends SpecBase
+    with TestActorSystem
+    with Matchers
+    with OptionValues
+    with ScalaFutures
+    with BeforeAndAfterEach
+    with PresentationFormats
+    with ModelGenerators
+    with ScalaCheckDrivenPropertyChecks {
+
+  "getBody" - {
+
+    "getting a small message" in {
+
+    }
+
+    "getting a large message" in {
+
+    }
+
+    "no message on pending message returns not found" in {
+
+    }
+
+    "no message on non-existing message ID returns not found" in {
+
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -283,7 +283,7 @@ class MovementsControllerSpec
         .thenReturn(departureDataEither)
 
       when(
-        mockObjectStoreService.addMessage(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId], any[Source[ByteString, _]])(
+        mockObjectStoreService.putObjectStoreFile(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId], any[Source[ByteString, _]])(
           any[ExecutionContext],
           any[HeaderCarrier]
         )
@@ -552,7 +552,7 @@ class MovementsControllerSpec
         .thenReturn(arrivalDataEither)
 
       when(
-        mockObjectStoreService.addMessage(
+        mockObjectStoreService.putObjectStoreFile(
           any[String].asInstanceOf[MovementId],
           any[String].asInstanceOf[MessageId],
           any[Source[ByteString, _]]
@@ -1056,7 +1056,7 @@ class MovementsControllerSpec
           .thenReturn(EitherT.rightT(MessageData(now, None)))
 
         when(
-          mockObjectStoreService.addMessage(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Source[ByteString, _]])(
+          mockObjectStoreService.putObjectStoreFile(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Source[ByteString, _]])(
             any(),
             any()
           )

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -22,7 +22,6 @@ import akka.util.ByteString
 import akka.util.Timeout
 import cats.data.EitherT
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.times
@@ -81,12 +80,15 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeParseException
 import java.util.UUID.randomUUID
+import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.xml.NodeSeq
 
+// this warning is a false one due to how the mock matchers work
+@nowarn("msg=dead code following this construct")
 class MovementsControllerSpec
     extends SpecBase
     with TestActorSystem

--- a/test/uk/gov/hmrc/transitmovements/controllers/ObjectStoreControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/ObjectStoreControllerSpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.controllers
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
+import org.mockito.MockitoSugar.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status.CREATED
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.OK
+import play.api.libs.json.JsSuccess
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers
+import play.api.test.Helpers.contentAsJson
+import play.api.test.Helpers.contentAsString
+import play.api.test.Helpers.defaultAwaitTimeout
+import play.api.test.Helpers.status
+import uk.gov.hmrc.objectstore.client.Md5Hash
+import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.transitmovements.base.SpecBase
+import uk.gov.hmrc.transitmovements.base.TestActorSystem
+import uk.gov.hmrc.transitmovements.generators.ModelGenerators
+import uk.gov.hmrc.transitmovements.models.MessageId
+import uk.gov.hmrc.transitmovements.models.MovementId
+import uk.gov.hmrc.transitmovements.models.ObjectStoreSummaryResponse
+import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
+import uk.gov.hmrc.transitmovements.services.ObjectStoreService
+import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
+
+import java.time.Instant
+import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext.Implicits.global
+
+// mocks are causing this warning, we don't need it.
+@nowarn("msg=dead code following this construct")
+class ObjectStoreControllerSpec extends SpecBase with ModelGenerators with ScalaCheckDrivenPropertyChecks with TestActorSystem {
+
+  "get" - {
+    "a valid URI returns a stream" in forAll(arbitrary[ObjectStoreURI]) {
+      objectStoreURI =>
+        val sampleSource           = Source.single[ByteString](ByteString("test object"))
+        val mockObjectStoreService = mock[ObjectStoreService]
+        when(mockObjectStoreService.getObjectStoreFile(eqTo(objectStoreURI.asResourceLocation.get))(any(), any())).thenReturn(EitherT.rightT(sampleSource))
+
+        val sut    = new ObjectStoreController(Helpers.stubControllerComponents(), mockObjectStoreService)
+        val result = sut.getObject(objectStoreURI)(FakeRequest("GET", s"object/${objectStoreURI.value}"))
+
+        status(result) mustBe OK
+        contentAsString(result) mustBe "test object"
+    }
+
+    "an invalid URI returns NotFound" in forAll(arbitrary[ObjectStoreURI]) {
+      objectStoreURI =>
+        val mockObjectStoreService = mock[ObjectStoreService]
+        when(mockObjectStoreService.getObjectStoreFile(eqTo(objectStoreURI.asResourceLocation.get))(any(), any()))
+          .thenReturn(EitherT.leftT(ObjectStoreError.FileNotFound(objectStoreURI.value)))
+
+        val sut    = new ObjectStoreController(Helpers.stubControllerComponents(), mockObjectStoreService)
+        val result = sut.getObject(objectStoreURI)(FakeRequest("GET", s"object/${objectStoreURI.value}"))
+
+        status(result) mustBe NOT_FOUND
+    }
+  }
+
+  "put (with message and movement ID)" - {
+    "a successful put returns the object information" in forAll(arbitrary[MovementId], arbitrary[MessageId]) {
+      (movementId, messageId) =>
+        val sampleStream = Source.single[ByteString](ByteString("test"))
+        val now          = Instant.now()
+        val objectSummary = ObjectSummaryWithMd5(
+          Path.File(Path.Directory(s"transit-movements/movements/${movementId.value}"), s"${movementId.value}-${messageId.value}-date.xml"),
+          4,
+          Md5Hash("098f6bcd4621d373cade4e832627b4f6"),
+          now
+        )
+        val mockObjectStoreService = mock[ObjectStoreService]
+        when(mockObjectStoreService.putObjectStoreFile(eqTo(movementId), eqTo(messageId), eqTo(sampleStream))(any(), any()))
+          .thenReturn(EitherT.rightT(objectSummary))
+
+        val sut = new ObjectStoreController(Helpers.stubControllerComponents(), mockObjectStoreService)
+        val result = sut.putObject(movementId, messageId)(
+          FakeRequest("POST", s"object/movement/${movementId.value}/message/${messageId.value}", FakeHeaders(), sampleStream)
+        )
+
+        status(result) mustBe CREATED
+        contentAsJson(result).validate[ObjectStoreSummaryResponse] mustBe JsSuccess(
+          ObjectStoreSummaryResponse(
+            s"transit-movements/movements/${movementId.value}/${movementId.value}-${messageId.value}-date.xml",
+            4,
+            "098f6bcd4621d373cade4e832627b4f6",
+            now
+          )
+        )
+    }
+
+    "a failed put returns an error" in forAll(arbitrary[MovementId], arbitrary[MessageId]) {
+      (movementId, messageId) =>
+        val sampleStream           = Source.single[ByteString](ByteString("test"))
+        val mockObjectStoreService = mock[ObjectStoreService]
+        when(mockObjectStoreService.putObjectStoreFile(eqTo(movementId), eqTo(messageId), eqTo(sampleStream))(any(), any()))
+          .thenReturn(EitherT.leftT(ObjectStoreError.UnexpectedError(None)))
+
+        val sut = new ObjectStoreController(Helpers.stubControllerComponents(), mockObjectStoreService)
+        val result = sut.putObject(movementId, messageId)(
+          FakeRequest("POST", s"object/movement/${movementId.value}/message/${messageId.value}", FakeHeaders(), sampleStream)
+        )
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.transitmovements.models.Movement
 import uk.gov.hmrc.transitmovements.models.MovementId
 import uk.gov.hmrc.transitmovements.models.MovementReferenceNumber
 import uk.gov.hmrc.transitmovements.models.MovementType
+import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
 import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 
@@ -152,5 +153,21 @@ trait ModelGenerators extends BaseGenerators {
   implicit lazy val arbitraryMessageStatus: Arbitrary[MessageStatus] =
     Arbitrary {
       Gen.oneOf(MessageStatus.statusValues)
+    }
+
+  lazy val dateTimeFormat = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+
+  private val objectStoreOwner = "common-transit-convention-traders"
+
+  def testObjectStoreURI(movementId: MovementId, messageId: MessageId, dateTime: OffsetDateTime): ObjectStoreURI =
+    ObjectStoreURI(s"$objectStoreOwner/movements/${movementId.value}/${movementId.value}-${messageId.value}-${dateTimeFormat.format(dateTime)}.xml")
+
+  implicit lazy val arbitraryObjectStoreURI: Arbitrary[ObjectStoreURI] =
+    Arbitrary {
+      for {
+        movementId <- arbitrary[MovementId]
+        messageId  <- arbitrary[MessageId]
+        dateTime   <- arbitrary[OffsetDateTime]
+      } yield testObjectStoreURI(movementId, messageId, dateTime)
     }
 }

--- a/test/uk/gov/hmrc/transitmovements/services/ObjectStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/ObjectStoreServiceSpec.scala
@@ -17,13 +17,15 @@
 package uk.gov.hmrc.transitmovements.services
 
 import akka.NotUsed
-import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito.reset
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.MockitoSugar.when
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures.whenReady
 import org.scalatest.freespec.AnyFreeSpec
@@ -31,6 +33,7 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.MimeTypes
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
@@ -38,9 +41,8 @@ import uk.gov.hmrc.objectstore.client.Md5Hash
 import uk.gov.hmrc.objectstore.client.Object
 import uk.gov.hmrc.objectstore.client.ObjectMetadata
 import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
-import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.{Path => OSPath}
 import uk.gov.hmrc.objectstore.client.RetentionPeriod
-import uk.gov.hmrc.objectstore.client.Path.File
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import uk.gov.hmrc.transitmovements.base.StreamTestHelpers
 import uk.gov.hmrc.transitmovements.base.TestActorSystem
@@ -52,10 +54,15 @@ import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
 
 import java.time.Clock
 import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.UUID.randomUUID
+import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@nowarn("msg=dead code following this construct")
 class ObjectStoreServiceSpec
     extends AnyFreeSpec
     with Matchers
@@ -68,22 +75,25 @@ class ObjectStoreServiceSpec
 
   implicit val hc: HeaderCarrier                           = HeaderCarrier()
   private val mockObjectStoreClient: PlayObjectStoreClient = mock[PlayObjectStoreClient]
+  private val dateTimeFormatter                            = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").withZone(ZoneOffset.UTC)
+  private val now                                          = OffsetDateTime.now(ZoneOffset.UTC)
+  private val clock                                        = Clock.fixed(now.toInstant, ZoneOffset.UTC)
 
   override def beforeEach: Unit =
     reset(mockObjectStoreClient)
 
-  "Object Store service" - {
+  "getObjectStoreFile" - {
 
     "should return the contents of a file" in {
       val filePath =
-        Path.Directory(s"movements/${arbitraryMovementId.arbitrary.sample.get}").file(randomUUID.toString).asUri
+        OSPath.Directory(s"movements/${arbitraryMovementId.arbitrary.sample.get}").file(randomUUID.toString).asUri
       val metadata    = ObjectMetadata("", 0, Md5Hash(""), Instant.now(), Map.empty[String, String])
       val content     = "content"
-      val fileContent = Option[Object[Source[ByteString, NotUsed]]](Object.apply(File(filePath), Source.single(ByteString(content)), metadata))
+      val fileContent = Option[Object[Source[ByteString, NotUsed]]](Object.apply(OSPath.File(filePath), Source.single(ByteString(content)), metadata))
 
-      when(mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](eqTo(Path.File(filePath)), eqTo("common-transit-convention-traders"))(any(), any()))
+      when(mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](eqTo(OSPath.File(filePath)), eqTo("common-transit-convention-traders"))(any(), any()))
         .thenReturn(Future.successful(fileContent))
-      val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
+      val service = new ObjectStoreServiceImpl()(materializer, clock, mockObjectStoreClient)
       val result  = service.getObjectStoreFile(ObjectStoreResourceLocation(filePath))
       whenReady(result.value) {
         r =>
@@ -94,8 +104,8 @@ class ObjectStoreServiceSpec
     }
 
     "should return an error when the file is not found on path" in {
-      when(mockObjectStoreClient.getObject(any[File](), eqTo("common-transit-convention-traders"))(any(), any())).thenReturn(Future.successful(None))
-      val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
+      when(mockObjectStoreClient.getObject(any[OSPath.File](), eqTo("common-transit-convention-traders"))(any(), any())).thenReturn(Future.successful(None))
+      val service = new ObjectStoreServiceImpl()(materializer, clock, mockObjectStoreClient)
 
       val result = service.getObjectStoreFile(ObjectStoreResourceLocation("abc/movement/abc.xml"))
       whenReady(result.value) {
@@ -109,8 +119,8 @@ class ObjectStoreServiceSpec
     "on a failed submission, should return a Left with an UnexpectedError" in {
       val error = UpstreamErrorResponse("error", INTERNAL_SERVER_ERROR)
 
-      when(mockObjectStoreClient.getObject(any[File](), eqTo("common-transit-convention-traders"))(any(), any())).thenReturn(Future.failed(error))
-      val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
+      when(mockObjectStoreClient.getObject(any[OSPath.File](), eqTo("common-transit-convention-traders"))(any(), any())).thenReturn(Future.failed(error))
+      val service = new ObjectStoreServiceImpl()(materializer, clock, mockObjectStoreClient)
       val result  = service.getObjectStoreFile(ObjectStoreResourceLocation("abc/movement/abc.xml"))
       whenReady(result.value) {
         case Left(_: ObjectStoreError.UnexpectedError) => succeed
@@ -118,65 +128,86 @@ class ObjectStoreServiceSpec
           fail(s"Expected Left(ObjectStoreError.UnexpectedError), instead got $x")
       }
     }
+  }
 
-    "should add the content to a file" in {
-      val objectSummary: ObjectSummaryWithMd5 = arbitraryObjectSummaryWithMd5.arbitrary.sample.get
+  "putObjectStoreFile" - {
 
-      val filePath =
-        Path.Directory(s"movements/${arbitraryMovementId.arbitrary.sample.get}").file(randomUUID.toString).asUri
+    "should add the content to a file" in forAll(arbitrary[MovementId], arbitrary[MessageId]) {
+      (movementId, messageId) =>
+        val objectSummary: ObjectSummaryWithMd5 = arbitraryObjectSummaryWithMd5.arbitrary.sample.get
 
-      val file                          = new java.io.File("test/uk/gov/hmrc/transitmovements/data/valid.xml")
-      val path: java.nio.file.Path      = file.toPath
-      val source: Source[ByteString, _] = FileIO.fromPath(path)
+        val source: Source[ByteString, _] = Source.single(ByteString("<test>test</test>"))
 
-      when(
-        mockObjectStoreClient.putObject(
-          path = any[File],
-          content = eqTo(source),
-          retentionPeriod = any[RetentionPeriod],
-          contentType = any[Option[String]],
-          contentMd5 = any[Option[Md5Hash]],
-          owner = eqTo("common-transit-convention-traders")
-        )(any(), any())
-      )
-        .thenReturn(Future.successful(objectSummary))
-      val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
+        when(
+          mockObjectStoreClient.putObject(
+            path = eqTo(
+              OSPath.Directory(s"movements/${movementId.value}").file(s"${movementId.value}-${messageId.value}-${dateTimeFormatter.format(now)}.xml")
+            ),
+            content = eqTo(source),
+            retentionPeriod = any[RetentionPeriod],
+            contentType = eqTo(Some(MimeTypes.XML)),
+            contentMd5 = any[Option[Md5Hash]],
+            owner = eqTo("common-transit-convention-traders")
+          )(any(), any())
+        )
+          .thenReturn(Future.successful(objectSummary))
+        val service = new ObjectStoreServiceImpl()(materializer, clock, mockObjectStoreClient)
 
-      val result = service.putObjectStoreFile(MovementId("123"), MessageId("123"), source)
-      whenReady(result.value) {
-        r =>
-          r.isRight mustBe true
-          r.toOption.get mustBe objectSummary
-      }
+        val result = service.putObjectStoreFile(movementId, messageId, source)
+        whenReady(result.value) {
+          r =>
+            r mustBe Right(objectSummary)
+
+            verify(mockObjectStoreClient, times(1)).putObject(
+              path = eqTo(
+                OSPath.Directory(s"movements/${movementId.value}").file(s"${movementId.value}-${messageId.value}-${dateTimeFormatter.format(now)}.xml")
+              ),
+              content = eqTo(source),
+              retentionPeriod = any[RetentionPeriod],
+              contentType = eqTo(Some(MimeTypes.XML)),
+              contentMd5 = any[Option[Md5Hash]],
+              owner = eqTo("common-transit-convention-traders")
+            )(any(), any())
+        }
     }
 
-    "on a failed submission of content in Object store, should return a left" in {
-      val file                          = new java.io.File("test/uk/gov/hmrc/transitmovements/data/valid.xml")
-      val path: java.nio.file.Path      = file.toPath
-      val source: Source[ByteString, _] = FileIO.fromPath(path)
+    "on a failed submission of content in Object store, should return a left" in forAll(arbitrary[MovementId], arbitrary[MessageId]) {
+      (movementId, messageId) =>
+        val source: Source[ByteString, _] = Source.single(ByteString("<test>test</test>"))
 
-      val error = ObjectStoreError.UnexpectedError(Some(new Throwable("test")))
-      when(
-        mockObjectStoreClient.putObject(
-          path = any[File],
-          content = eqTo(source),
-          retentionPeriod = any[RetentionPeriod],
-          contentType = any[Option[String]],
-          contentMd5 = any[Option[Md5Hash]],
-          owner = eqTo("common-transit-convention-traders")
-        )(any(), any())
-      )
-        .thenReturn(Future.failed(error))
-      val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
-      val result  = service.putObjectStoreFile(MovementId("123"), MessageId("123"), source)
+        val error = ObjectStoreError.UnexpectedError(Some(new Throwable("test")))
+        when(
+          mockObjectStoreClient.putObject(
+            path = eqTo(
+              OSPath.Directory(s"movements/${movementId.value}").file(s"${movementId.value}-${messageId.value}-${dateTimeFormatter.format(now)}.xml")
+            ),
+            content = eqTo(source),
+            retentionPeriod = any[RetentionPeriod],
+            contentType = eqTo(Some(MimeTypes.XML)),
+            contentMd5 = any[Option[Md5Hash]],
+            owner = eqTo("common-transit-convention-traders")
+          )(any(), any())
+        )
+          .thenReturn(Future.failed(error))
+        val service = new ObjectStoreServiceImpl()(materializer, clock, mockObjectStoreClient)
+        val result  = service.putObjectStoreFile(movementId, messageId, source)
 
-      whenReady(result.value) {
-        case Left(_: ObjectStoreError.UnexpectedError) => succeed
-        case x =>
-          fail(s"Expected Left(ObjectStoreError.UnexpectedError), instead got $x")
-      }
+        whenReady(result.value) {
+          case Left(_: ObjectStoreError.UnexpectedError) =>
+            verify(mockObjectStoreClient, times(1)).putObject(
+              path = eqTo(
+                OSPath.Directory(s"movements/${movementId.value}").file(s"${movementId.value}-${messageId.value}-${dateTimeFormatter.format(now)}.xml")
+              ),
+              content = eqTo(source),
+              retentionPeriod = any[RetentionPeriod],
+              contentType = eqTo(Some(MimeTypes.XML)),
+              contentMd5 = any[Option[Md5Hash]],
+              owner = eqTo("common-transit-convention-traders")
+            )(any(), any())
+          case x =>
+            fail(s"Expected Left(ObjectStoreError.UnexpectedError), instead got $x")
+        }
     }
-
   }
 
 }

--- a/test/uk/gov/hmrc/transitmovements/services/ObjectStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/ObjectStoreServiceSpec.scala
@@ -142,7 +142,7 @@ class ObjectStoreServiceSpec
         .thenReturn(Future.successful(objectSummary))
       val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
 
-      val result = service.addMessage(MovementId("123"), MessageId("123"), source)
+      val result = service.putObjectStoreFile(MovementId("123"), MessageId("123"), source)
       whenReady(result.value) {
         r =>
           r.isRight mustBe true
@@ -168,7 +168,7 @@ class ObjectStoreServiceSpec
       )
         .thenReturn(Future.failed(error))
       val service = new ObjectStoreServiceImpl()(materializer, Clock.systemUTC(), mockObjectStoreClient)
-      val result  = service.addMessage(MovementId("123"), MessageId("123"), source)
+      val result  = service.putObjectStoreFile(MovementId("123"), MessageId("123"), source)
 
       whenReady(result.value) {
         case Left(_: ObjectStoreError.UnexpectedError) => succeed


### PR DESCRIPTION
Part 1 of X of the `object-store` in `transit-movements` only stuff.

# Why are we doing this?

PlatOps have asked us to treat object-store in the same way we treat Mongo -- only have a service that owns a file access  that file (so no `transit-movements-router` accessing `common-transit-convention-traders` objects.

# What does this PR do?

This PR adds three routes:

* A route to get a file by object store path, `GET /transit-movements/object/{objectStoreURI}` (the URI includes the owner)
* A route to put a file by movement and message ID, `PUT /transit-movements/object/movement/:movementId/message/:messageId`
* A route to get a file's content's by movement and message ID, `GET /transit-movements/traders/:EORI/movements/:movementType/:movementId/messages/:messageId/body`

This will allow us to make simple swaps in _most_ of our code, from the object store client to transit-movements. The one place this can't happen yet is the router with files coming back from SDES. I intend to update the add new message (without empty message first) route in `transit-movements` to support this properly.

We will also need to adjust the copy code in the router, we'll likely have to ask PlatOps if an exception to copy is okay, else we'll stream out and stream in (or do the copy in transit-movements and provide a transit-movements URI)

# What does this PR not do?

* It does not alter any existing logic. There is work to be done to make the creating new message stuff more streamlined but it works right now and I'm not going to touch it while things are in flux. That's tech debt that'll be captured and done later.
* It does not yet read from Upscan, but the intention is that the PATCH call will take an Upscan URL instead, or we'll add a PUT call on the message body controller so that we can eventually hide object store even being a thing in most services.
* Change the owner of the files to `transit-movements` _yet_, we'll do that once we've pointed all services to `transit-movements` to avoid disruption while other development is going on.

# What's next?

* We should add internal auth to our endpoints
* We need our current services to use these object store routes instead of the client
* We need to update the add message route to support the router, which doesn't have a message ID at the current point we update 
* We need to support copying files for SDES in the router