### PR TITLE
CTCP-2571, CTCP-2452: Add create body endpoint

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -41,7 +41,6 @@ import uk.gov.hmrc.transitmovements.models.MovementId
 import uk.gov.hmrc.transitmovements.models.MovementType
 import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
 import uk.gov.hmrc.transitmovements.models.UpdateMessageData
-import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
 import uk.gov.hmrc.transitmovements.services.MessageService
@@ -153,7 +152,7 @@ class MessageBodyController @Inject() (
         movementId,
         extractedData.map(_.movementEoriNumber),
         extractedData.flatMap(_.movementReferenceNumber).orElse(messageData.mrn),
-        messageData.generationDate
+        received
       )
       .asPresentation
 }

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -96,7 +96,7 @@ class MessageBodyController @Inject() (
           messageType   <- extract(request.headers).asPresentation
           messageData   <- messagesXmlParsingService.extractMessageData(request.body, messageType).asPresentation
           extractedData <- movementsXmlParsingService.extractData(messageType, request.body).asPresentation
-          bodyStorage   <- messageService.storeIfAppropriate(movementId, messageId, size, request.body).asPresentation
+          bodyStorage   <- messageService.storeIfLarge(movementId, messageId, size, request.body).asPresentation
           _ <- repo
             .updateMessage(
               movementId,

--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -16,11 +16,13 @@
 
 package uk.gov.hmrc.transitmovements.controllers
 
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import cats.data.EitherT
 import play.api.Logging
 import play.api.http.MimeTypes
+import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
@@ -29,24 +31,47 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.transitmovements.controllers.errors.ConvertError
 import uk.gov.hmrc.transitmovements.controllers.errors.PresentationError
+import uk.gov.hmrc.transitmovements.controllers.stream.StreamingParsers
 import uk.gov.hmrc.transitmovements.models.EORINumber
+import uk.gov.hmrc.transitmovements.models.ExtractedData
+import uk.gov.hmrc.transitmovements.models.MessageData
 import uk.gov.hmrc.transitmovements.models.MessageId
+import uk.gov.hmrc.transitmovements.models.MessageStatus
 import uk.gov.hmrc.transitmovements.models.MovementId
 import uk.gov.hmrc.transitmovements.models.MovementType
 import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
+import uk.gov.hmrc.transitmovements.models.UpdateMessageData
+import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
+import uk.gov.hmrc.transitmovements.services.MessageService
+import uk.gov.hmrc.transitmovements.services.MessagesXmlParsingService
+import uk.gov.hmrc.transitmovements.services.MovementsXmlParsingService
 import uk.gov.hmrc.transitmovements.services.ObjectStoreService
 
+import java.time.Clock
+import java.time.OffsetDateTime
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class MessageBodyController @Inject() (cc: ControllerComponents, repo: MovementsRepository, objectStoreService: ObjectStoreService)(implicit
-  ec: ExecutionContext
+class MessageBodyController @Inject() (
+  cc: ControllerComponents,
+  repo: MovementsRepository,
+  objectStoreService: ObjectStoreService,
+  messagesXmlParsingService: MessagesXmlParsingService,
+  movementsXmlParsingService: MovementsXmlParsingService,
+  messageService: MessageService,
+  clock: Clock
+)(implicit
+  ec: ExecutionContext,
+  val materializer: Materializer,
+  temporaryFileCreator: TemporaryFileCreator
 ) extends BackendController(cc)
     with Logging
+    with StreamingParsers
     with ConvertError
+    with MessageTypeHeaderExtractor
     with ObjectStoreURIHelpers {
 
   def getBody(eori: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[AnyContent] = Action.async {
@@ -60,6 +85,37 @@ class MessageBodyController @Inject() (cc: ControllerComponents, repo: Movements
           error => Future.successful(Status(error.code.statusCode)(Json.toJson(error)))
         )
   }
+
+  def createBody(eori: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[Source[ByteString, _]] =
+    Action.streamWithSize {
+      implicit request => size =>
+        val received = OffsetDateTime.now(clock)
+        (for {
+          maybeMessage  <- repo.getSingleMessage(eori, movementId, messageId, movementType).asPresentation
+          message       <- ensureMessage(maybeMessage, messageId, movementId)
+          _             <- ensureNoMessageBody(message)
+          messageType   <- extract(request.headers).asPresentation
+          messageData   <- messagesXmlParsingService.extractMessageData(request.body, messageType).asPresentation
+          extractedData <- movementsXmlParsingService.extractData(messageType, request.body).asPresentation
+          bodyStorage   <- messageService.storeIfAppropriate(movementId, messageId, size, request.body).asPresentation
+          _ <- repo
+            .updateMessage(
+              movementId,
+              messageId,
+              UpdateMessageData(bodyStorage.objectStore, bodyStorage.mongo, Some(size), messageType.statusOnAttach, Some(messageType)),
+              received
+            )
+            .asPresentation
+          _ <- updateMovementMetadata(movementId, extractedData, messageData, received)
+        } yield Created)
+          .valueOrF(
+            error => Future.successful(Status(error.code.statusCode)(Json.toJson(error)))
+          )
+    }
+
+  private def ensureNoMessageBody(messageResponse: MessageResponse): EitherT[Future, PresentationError, Unit] =
+    if (messageResponse.status.contains(MessageStatus.Pending)) EitherT.rightT((): Unit)
+    else EitherT.leftT(PresentationError.conflictError(s"Body for ${messageResponse.id.value} already exists"))
 
   private def ensureMessage(
     message: Option[MessageResponse],
@@ -85,4 +141,19 @@ class MessageBodyController @Inject() (cc: ControllerComponents, repo: Movements
 
   private def notFound[A](messageId: MessageId, movementId: MovementId): EitherT[Future, PresentationError, A] =
     EitherT.leftT(PresentationError.notFoundError(s"Body of message ID ${messageId.value} for movement ID ${movementId.value} was not found"))
+
+  private def updateMovementMetadata(
+    movementId: MovementId,
+    extractedData: Option[ExtractedData],
+    messageData: MessageData,
+    received: OffsetDateTime
+  ): EitherT[Future, PresentationError, Unit] =
+    repo
+      .updateMovement(
+        movementId,
+        extractedData.map(_.movementEoriNumber),
+        extractedData.flatMap(_.movementReferenceNumber).orElse(messageData.mrn),
+        messageData.generationDate
+      )
+      .asPresentation
 }

--- a/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
@@ -308,7 +308,7 @@ class MovementsController @Inject() (
     movementType: MovementType,
     movementToUpdate: MovementWithoutMessages,
     objectStoreURI: Option[ObjectStoreURI],
-    receieved: OffsetDateTime
+    received: OffsetDateTime
   )(implicit hc: HeaderCarrier): EitherT[Future, PresentationError, Unit] =
     (movementToUpdate.movementEORINumber, objectStoreURI) match {
       case (None, Some(location)) =>
@@ -317,7 +317,7 @@ class MovementsController @Inject() (
           source           <- objectStoreService.getObjectStoreFile(resourceLocation).asPresentation
           extractedData    <- movementsXmlParsingService.extractData(movementType, source).asPresentation
           _ <- repo
-            .updateMovement(movementId, Some(extractedData.movementEoriNumber), extractedData.movementReferenceNumber, receieved)
+            .updateMovement(movementId, Some(extractedData.movementEoriNumber), extractedData.movementReferenceNumber, received)
             .asPresentation
         } yield ()
       case _ => EitherT.rightT((): Unit)

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCode.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ErrorCode.scala
@@ -32,6 +32,7 @@ object ErrorCode {
   case object InternalServerError  extends ErrorCode("INTERNAL_SERVER_ERROR", INTERNAL_SERVER_ERROR)
   case object GatewayTimeout       extends ErrorCode("GATEWAY_TIMEOUT", GATEWAY_TIMEOUT)
   case object UnsupportedMediaType extends ErrorCode("UNSUPPORTED_MEDIA_TYPE", UNSUPPORTED_MEDIA_TYPE)
+  case object Conflict             extends ErrorCode("CONFLICT", CONFLICT)
 
   lazy val errorCodes: Seq[ErrorCode] = Seq(
     BadRequest,
@@ -39,7 +40,8 @@ object ErrorCode {
     Forbidden,
     InternalServerError,
     GatewayTimeout,
-    UnsupportedMediaType
+    UnsupportedMediaType,
+    Conflict
   )
 
   implicit val errorCodeWrites: Writes[ErrorCode] = Writes {
@@ -50,4 +52,5 @@ object ErrorCode {
     case JsString(errorCode) => errorCodes.find(_.code == errorCode).map(JsSuccess(_)).getOrElse(JsError())
     case _                   => JsError()
   }
+
 }

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/PresentationError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/PresentationError.scala
@@ -44,6 +44,9 @@ object PresentationError extends CommonFormats with Logging {
   def notFoundError(message: String): PresentationError =
     StandardError(message, ErrorCode.NotFound)
 
+  def conflictError(message: String): PresentationError =
+    StandardError(message, ErrorCode.Conflict)
+
   def upstreamServiceError(
     message: String = "Internal server error",
     code: ErrorCode = ErrorCode.InternalServerError,

--- a/app/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsers.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/stream/StreamingParsers.scala
@@ -71,33 +71,12 @@ trait StreamingParsers {
     def stream(
       block: (Request[Source[ByteString, _]]) => Future[Result]
     )(implicit temporaryFileCreator: TemporaryFileCreator): Action[Source[ByteString, _]] =
-      actionBuilder.async(streamFromMemory) {
-        request =>
-          // This is outside the for comprehension because we need access to the file
-          // if the rest of the futures fail, which we wouldn't get if it was in there.
-          Future
-            .fromTry(Try(temporaryFileCreator.create()))
-            .flatMap {
-              file =>
-                (for {
-                  _      <- request.body.runWith(FileIO.toPath(file))
-                  result <- block(request.withBody(FileIO.fromPath(file)))
-                } yield result)
-                  .attemptTap {
-                    _ =>
-                      file.delete()
-                      Future.successful(())
-                  }
-            }
-            .recover {
-              case NonFatal(ex) =>
-                logger.error(s"Failed call: ${ex.getMessage}", ex)
-                Status(INTERNAL_SERVER_ERROR)(Json.toJson(PresentationError.internalServiceError(cause = Some(ex))))
-            }
-      }
+      streamWithSize(
+        request => _ => block(request)
+      )
 
     def streamWithSize(
-      block: (Request[Source[ByteString, _]], Long) => Future[Result]
+      block: Request[Source[ByteString, _]] => Long => Future[Result]
     )(implicit temporaryFileCreator: TemporaryFileCreator): Action[Source[ByteString, _]] =
       actionBuilder.async(streamFromMemory) {
         request =>
@@ -110,7 +89,7 @@ trait StreamingParsers {
                 (for {
                   _      <- request.body.runWith(FileIO.toPath(file))
                   size   <- Future.fromTry(Try(Files.size(file)))
-                  result <- block(request.withBody(FileIO.fromPath(file)), size)
+                  result <- block(request.withBody(FileIO.fromPath(file)))(size)
                 } yield result)
                   .attemptTap {
                     _ =>

--- a/app/uk/gov/hmrc/transitmovements/models/BodyStorage.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/BodyStorage.scala
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.transitmovements.models.requests
+package uk.gov.hmrc.transitmovements.models
 
-import play.api.libs.json.Format
-import play.api.libs.json.Json
-import uk.gov.hmrc.transitmovements.models.MessageStatus
+object BodyStorage {
+  def mongo(mongo: String) = new BodyStorage(Some(mongo), None)
 
-object UpdateStatus {
-  implicit val updateStatusFormat: Format[UpdateStatus] = Json.format[UpdateStatus]
+  def objectStore(objectStoreURI: ObjectStoreURI) = new BodyStorage(None, Some(objectStoreURI))
 }
 
-final case class UpdateStatus(status: MessageStatus)
+case class BodyStorage private (mongo: Option[String], objectStore: Option[ObjectStoreURI])

--- a/app/uk/gov/hmrc/transitmovements/models/UpdateMessageData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/UpdateMessageData.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.models
+
+import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
+import uk.gov.hmrc.transitmovements.models.requests.UpdateStatus
+
+object UpdateMessageData {
+  def apply(status: UpdateStatus): UpdateMessageData            = UpdateMessageData(None, None, None, status.status, None)
+  def apply(metadata: UpdateMessageMetadata): UpdateMessageData = UpdateMessageData(metadata.objectStoreURI, None, None, metadata.status, metadata.messageType)
+}
+
+final case class UpdateMessageData(
+  objectStoreURI: Option[ObjectStoreURI] = None,
+  body: Option[String] = None,
+  size: Option[Long] = None,
+  status: MessageStatus,
+  messageType: Option[MessageType] = None
+)

--- a/app/uk/gov/hmrc/transitmovements/models/responses/MessageResponse.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/responses/MessageResponse.scala
@@ -29,7 +29,7 @@ import java.time.OffsetDateTime
 case class MessageResponse(
   id: MessageId,
   received: OffsetDateTime,
-  messageType: MessageType,
+  messageType: Option[MessageType],
   body: Option[String],
   status: Option[MessageStatus],
   uri: Option[URI] = None
@@ -49,7 +49,7 @@ object MessageResponse {
     MessageResponse(
       message.id,
       message.received,
-      message.messageType,
+      Some(message.messageType),
       message.body,
       message.status,
       None
@@ -59,7 +59,7 @@ object MessageResponse {
     MessageResponse(
       message.id,
       message.received,
-      message.messageType,
+      Some(message.messageType),
       None,
       message.status,
       message.uri

--- a/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
+++ b/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
@@ -45,7 +45,6 @@ import uk.gov.hmrc.transitmovements.models.MovementWithoutMessages
 import uk.gov.hmrc.transitmovements.models.UpdateMessageData
 import uk.gov.hmrc.transitmovements.models.formats.CommonFormats
 import uk.gov.hmrc.transitmovements.models.formats.MongoFormats
-import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepositoryImpl.EPOCH_TIME
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
@@ -376,7 +375,7 @@ class MovementsRepositoryImpl @Inject() (
     movementId: MovementId,
     movementEORI: Option[EORINumber],
     mrn: Option[MovementReferenceNumber],
-    received: OffsetDateTime
+    updated: OffsetDateTime
   ): EitherT[Future, MongoError, Unit] = {
     val filter: Bson = mEq(movementId.value)
 
@@ -394,7 +393,7 @@ class MovementsRepositoryImpl @Inject() (
 
     // If we don't have to update anything, don't bother going to Mongo.
     if (combined.isEmpty) EitherT.rightT(())
-    else executeUpdate(movementId, filter, combined ++ Seq(mSet("updated", received)))
+    else executeUpdate(movementId, filter, combined ++ Seq(mSet("updated", updated)))
   }
 
   private def executeUpdate(

--- a/app/uk/gov/hmrc/transitmovements/services/MessageService.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MessageService.scala
@@ -75,7 +75,7 @@ trait MessageService {
     received: OffsetDateTime
   ): Message
 
-  def storeIfAppropriate(movementId: MovementId, messageId: MessageId, size: Long, src: Source[ByteString, _])(implicit
+  def storeIfLarge(movementId: MovementId, messageId: MessageId, size: Long, src: Source[ByteString, _])(implicit
     hc: HeaderCarrier
   ): EitherT[Future, StreamError, BodyStorage]
 
@@ -104,7 +104,7 @@ class MessageServiceImpl @Inject() (
     status: MessageStatus
   )(implicit hc: HeaderCarrier): EitherT[Future, StreamError, Message] = {
     val messageId = generateId()
-    storeIfAppropriate(movementId, messageId, size, source).map {
+    storeIfLarge(movementId, messageId, size, source).map {
       bodyStorage =>
         Message(
           id = messageId,
@@ -156,7 +156,7 @@ class MessageServiceImpl @Inject() (
       status = Some(MessageStatus.Pending)
     )
 
-  override def storeIfAppropriate(movementId: MovementId, messageId: MessageId, size: Long, src: Source[ByteString, _])(implicit
+  override def storeIfLarge(movementId: MovementId, messageId: MessageId, size: Long, src: Source[ByteString, _])(implicit
     hc: HeaderCarrier
   ): EitherT[Future, StreamError, BodyStorage] =
     if (smallMessageLimitService.isLarge(size)) createObjectStoreObject(movementId, messageId, src).map(BodyStorage.objectStore)

--- a/app/uk/gov/hmrc/transitmovements/services/MessageService.scala
+++ b/app/uk/gov/hmrc/transitmovements/services/MessageService.scala
@@ -39,7 +39,6 @@ import java.security.SecureRandom
 import java.time.Clock
 import java.time.OffsetDateTime
 import javax.inject.Inject
-import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,6 +22,8 @@ PATCH      /traders/movements/:movementId/messages/:messageId                   
 
 GET        /traders/:EORI/movements/:movementType/:movementId/messages/:messageId/body uk.gov.hmrc.transitmovements.controllers.MessageBodyController.getBody(EORI: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId)
 
+POST       /traders/:EORI/movements/:movementType/:movementId/messages/:messageId/body uk.gov.hmrc.transitmovements.controllers.MessageBodyController.createBody(EORI: EORINumber, movementType: MovementType, movementId: MovementId, messageId: MessageId)
+
 # -- Object Store facade -- to be removed when proper refactoring is completed.
 
 GET        /object/*location                                                        uk.gov.hmrc.transitmovements.controllers.ObjectStoreController.getObject(location: ObjectStoreURI)

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
@@ -538,7 +538,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(
@@ -603,7 +603,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(
@@ -668,7 +668,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(
@@ -734,7 +734,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(
@@ -1081,7 +1081,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.leftT(StreamError.UnexpectedError(None)))
 
         val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
@@ -1135,7 +1135,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(
@@ -1198,7 +1198,7 @@ class MessageBodyControllerSpec
 
         when(
           messageService
-            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+            .storeIfLarge(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
         ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
 
         when(

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
@@ -35,6 +35,8 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.http.Status.NOT_FOUND
 import play.api.http.Status.OK
+import play.api.libs.Files.SingletonTemporaryFileCreator
+import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.test.FakeRequest
@@ -56,11 +58,15 @@ import uk.gov.hmrc.transitmovements.models.ObjectStoreResourceLocation
 import uk.gov.hmrc.transitmovements.models.formats.PresentationFormats
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
+import uk.gov.hmrc.transitmovements.services.MessageService
+import uk.gov.hmrc.transitmovements.services.MessagesXmlParsingService
+import uk.gov.hmrc.transitmovements.services.MovementsXmlParsingService
 import uk.gov.hmrc.transitmovements.services.ObjectStoreService
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
 import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
 
 import java.net.URI
+import java.time.Clock
 import java.time.OffsetDateTime
 import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -78,7 +84,8 @@ class MessageBodyControllerSpec
     with ModelGenerators
     with ScalaCheckDrivenPropertyChecks {
 
-  private val now = OffsetDateTime.now()
+  private val now   = OffsetDateTime.now()
+  private val clock = Clock.fixed(now.toInstant, now.getOffset)
 
   "getBody" - {
 
@@ -120,9 +127,22 @@ class MessageBodyControllerSpec
         )
           .thenReturn(expectedResponse)
 
-        val mockObjectStoreService = mock[ObjectStoreService]
+        val mockObjectStoreService         = mock[ObjectStoreService]
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe OK
@@ -185,7 +205,21 @@ class MessageBodyControllerSpec
         when(mockObjectStoreService.getObjectStoreFile(ObjectStoreResourceLocation(eqTo(objectStoreUri.asResourceLocation.get.value)))(any(), any()))
           .thenReturn(EitherT.rightT(Source.single(ByteString(xml))))
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
+
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe OK
@@ -234,7 +268,21 @@ class MessageBodyControllerSpec
 
         val mockObjectStoreService = mock[ObjectStoreService]
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
+
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe NOT_FOUND
@@ -272,7 +320,21 @@ class MessageBodyControllerSpec
 
         val mockObjectStoreService = mock[ObjectStoreService]
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
+
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe NOT_FOUND
@@ -311,7 +373,21 @@ class MessageBodyControllerSpec
 
         val mockObjectStoreService = mock[ObjectStoreService]
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
+
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe NOT_FOUND
@@ -368,7 +444,21 @@ class MessageBodyControllerSpec
         when(mockObjectStoreService.getObjectStoreFile(ObjectStoreResourceLocation(eqTo(objectStoreUri.asResourceLocation.get.value)))(any(), any()))
           .thenReturn(EitherT.leftT(ObjectStoreError.FileNotFound("...")))
 
-        val sut                    = new MessageBodyController(stubControllerComponents(), mockMovementsRepo, mockObjectStoreService)
+        val mockMessagesXmlParsingSerivce  = mock[MessagesXmlParsingService]
+        val mockMovementsXmlParsingSerivce = mock[MovementsXmlParsingService]
+        val mockMessageService             = mock[MessageService]
+
+        implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+        val sut = new MessageBodyController(
+          stubControllerComponents(),
+          mockMovementsRepo,
+          mockObjectStoreService,
+          mockMessagesXmlParsingSerivce,
+          mockMovementsXmlParsingSerivce,
+          mockMessageService,
+          clock
+        )
         val result: Future[Result] = sut.getBody(eori, movementType, movementId, messageId)(FakeRequest("GET", "/"))
 
         status(result) mustBe INTERNAL_SERVER_ERROR

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
@@ -21,6 +21,7 @@ import akka.util.ByteString
 import cats.data.EitherT
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.argThat
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -32,6 +33,9 @@ import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.CONFLICT
+import play.api.http.Status.CREATED
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.http.Status.NOT_FOUND
 import play.api.http.Status.OK
@@ -39,20 +43,28 @@ import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.Files.TemporaryFileCreator
 import play.api.libs.json.Json
 import play.api.mvc.Result
+import play.api.test.FakeHeaders
 import play.api.test.FakeRequest
 import play.api.test.Helpers.contentAsJson
 import play.api.test.Helpers.contentAsString
 import play.api.test.Helpers.defaultAwaitTimeout
 import play.api.test.Helpers.status
 import play.api.test.Helpers.stubControllerComponents
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.transitmovements.base.SpecBase
 import uk.gov.hmrc.transitmovements.base.TestActorSystem
 import uk.gov.hmrc.transitmovements.generators.ModelGenerators
+import uk.gov.hmrc.transitmovements.matchers.UpdateMessageDataMatcher
+import uk.gov.hmrc.transitmovements.models.ArrivalData
+import uk.gov.hmrc.transitmovements.models.BodyStorage
+import uk.gov.hmrc.transitmovements.models.DeclarationData
 import uk.gov.hmrc.transitmovements.models.EORINumber
+import uk.gov.hmrc.transitmovements.models.MessageData
 import uk.gov.hmrc.transitmovements.models.MessageId
 import uk.gov.hmrc.transitmovements.models.MessageStatus
 import uk.gov.hmrc.transitmovements.models.MessageType
 import uk.gov.hmrc.transitmovements.models.MovementId
+import uk.gov.hmrc.transitmovements.models.MovementReferenceNumber
 import uk.gov.hmrc.transitmovements.models.MovementType
 import uk.gov.hmrc.transitmovements.models.ObjectStoreResourceLocation
 import uk.gov.hmrc.transitmovements.models.formats.PresentationFormats
@@ -64,10 +76,13 @@ import uk.gov.hmrc.transitmovements.services.MovementsXmlParsingService
 import uk.gov.hmrc.transitmovements.services.ObjectStoreService
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
 import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
+import uk.gov.hmrc.transitmovements.services.errors.ParseError
+import uk.gov.hmrc.transitmovements.services.errors.StreamError
 
 import java.net.URI
 import java.time.Clock
 import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
 import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -84,8 +99,9 @@ class MessageBodyControllerSpec
     with ModelGenerators
     with ScalaCheckDrivenPropertyChecks {
 
-  private val now   = OffsetDateTime.now()
-  private val clock = Clock.fixed(now.toInstant, now.getOffset)
+  private val now         = OffsetDateTime.now()
+  private val nowMinusOne = now.minusMinutes(1)
+  private val clock       = Clock.fixed(now.toInstant, now.getOffset)
 
   "getBody" - {
 
@@ -110,7 +126,7 @@ class MessageBodyControllerSpec
             MessageResponse(
               messageId,
               now,
-              messageType,
+              Some(messageType),
               Some(xml),
               Some(MessageStatus.Success),
               None
@@ -190,7 +206,7 @@ class MessageBodyControllerSpec
                     MessageResponse(
                       messageId,
                       now,
-                      messageType,
+                      Some(messageType),
                       None,
                       Some(MessageStatus.Success),
                       Some(new URI(objectStoreUri.value))
@@ -257,7 +273,7 @@ class MessageBodyControllerSpec
                 MessageResponse(
                   messageId,
                   now,
-                  messageType,
+                  Some(messageType),
                   None,
                   Some(MessageStatus.Pending),
                   None
@@ -431,7 +447,7 @@ class MessageBodyControllerSpec
                 MessageResponse(
                   messageId,
                   now,
-                  messageType,
+                  Some(messageType),
                   None,
                   Some(MessageStatus.Success),
                   Some(new URI(objectStoreUri.value))
@@ -476,6 +492,764 @@ class MessageBodyControllerSpec
         }
 
     }
+  }
+
+  "createBody" - {
+
+    "must return Created when the body has been created and is added to Mongo with no extra extracted data" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      arbitrary[MessageType],
+      arbitrary[MovementType],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, messageType, movementType, string) =>
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(None))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.rightT((): Unit))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(None), eqTo(None), eqTo(now))).thenReturn(EitherT.rightT((): Unit))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe CREATED
+    }
+
+    "must return Created when the body has been created and is added to Mongo with extra extracted arrival data" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[EORINumber],
+      arbitrary[MovementReferenceNumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementEori, movementReferenceNumber, movementId, messageId, string) =>
+        val messageType  = MessageType.ArrivalNotification
+        val movementType = MovementType.Arrival
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(Some(ArrivalData(movementEori, nowMinusOne, movementReferenceNumber))))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.rightT((): Unit))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(movementEori)), eqTo(Some(movementReferenceNumber)), eqTo(now)))
+          .thenReturn(EitherT.rightT((): Unit))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe CREATED
+    }
+
+    "must return Created when the body has been created and is added to Mongo with extra extracted departure data" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementEori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(Some(DeclarationData(movementEori, nowMinusOne))))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.rightT((): Unit))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(movementEori)), eqTo(None), eqTo(now)))
+          .thenReturn(EitherT.rightT((): Unit))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe CREATED
+    }
+
+    "must return Created when the body has been created and is added to Mongo with extra message data" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[EORINumber],
+      arbitrary[MovementReferenceNumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementEori, movementReferenceNumber, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, Some(movementReferenceNumber))))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(Some(DeclarationData(movementEori, nowMinusOne))))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.rightT((): Unit))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(movementEori)), eqTo(Some(movementReferenceNumber)), eqTo(now)))
+          .thenReturn(EitherT.rightT((): Unit))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe CREATED
+    }
+
+    "must return Not Found if the message doesn't exist" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, _, _, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(EitherT.rightT(None))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe NOT_FOUND
+    }
+
+    "must return Not Found if the movement doesn't exist" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, _, _, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(EitherT.leftT(MongoError.DocumentNotFound("test")))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe NOT_FOUND
+    }
+
+    "must return Conflict when the body already exists" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, _, _, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  Some(string),
+                  Some(MessageStatus.Processing),
+                  None
+                )
+              )
+            )
+          )
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe CONFLICT
+    }
+
+    "must return Bad Request if it cannot be parsed by the message data parser" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar),
+      Gen.oneOf(ParseError.NoElementFound("a"), ParseError.TooManyElementsFound("a"), ParseError.BadDateTime("a", new DateTimeParseException("a", "a", 0)))
+    ) {
+      (eori, movementId, messageId, string, ex) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, _, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.leftT(ex))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe BAD_REQUEST
+    }
+
+    "must return Internal Server Error if it throws an error during parsing by the message data parser" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, _, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.leftT(ParseError.UnexpectedError(None)))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+
+    "must return Bad Request if it cannot be parsed by the movement data parser" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar),
+      Gen.oneOf(ParseError.NoElementFound("a"), ParseError.TooManyElementsFound("a"), ParseError.BadDateTime("a", new DateTimeParseException("a", "a", 0)))
+    ) {
+      (eori, movementId, messageId, string, ex) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.leftT(ex))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe BAD_REQUEST
+    }
+
+    "must return Internal Server Error if it throws an error during parsing by the movement data parser" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, _) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.leftT(ParseError.UnexpectedError(None)))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+
+    "must return Internal Server Error if the object cannot be prepared for storage" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[EORINumber],
+      arbitrary[MovementReferenceNumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementEori, movementReferenceNumber, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, Some(movementReferenceNumber))))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(Some(DeclarationData(movementEori, nowMinusOne))))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.leftT(StreamError.UnexpectedError(None)))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+
+    "must return Internal Server Error when Mongo is unable to store a message" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[EORINumber],
+      arbitrary[MovementReferenceNumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementEori, movementReferenceNumber, movementId, messageId, string) =>
+        val messageType  = MessageType.DeclarationData
+        val movementType = MovementType.Departure
+
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, Some(movementReferenceNumber))))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(Some(DeclarationData(movementEori, nowMinusOne))))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.leftT(MongoError.UnexpectedError(None)))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(movementEori)), eqTo(Some(movementReferenceNumber)), eqTo(now)))
+          .thenReturn(EitherT.rightT((): Unit))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+
+    "must return Internal Server Error when Mongo is unable to update a movement" in forAll(
+      arbitrary[EORINumber],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      arbitrary[MessageType],
+      arbitrary[MovementType],
+      Gen.stringOfN(15, Gen.alphaNumChar)
+    ) {
+      (eori, movementId, messageId, messageType, movementType, string) =>
+        val ControllerAndMocks(sut, movementsRepository, _, messagesXmlParsingService, movementsXmlParsingService, messageService) = createController()
+
+        when(
+          movementsRepository.getSingleMessage(
+            EORINumber(eqTo(eori.value)),
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            eqTo(movementType)
+          )
+        )
+          .thenReturn(
+            EitherT.rightT(
+              Some(
+                MessageResponse(
+                  messageId,
+                  now,
+                  None,
+                  None,
+                  Some(MessageStatus.Pending),
+                  None
+                )
+              )
+            )
+          )
+
+        when(messagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
+          .thenReturn(EitherT.rightT(MessageData(now, None)))
+
+        when(movementsXmlParsingService.extractData(eqTo(messageType), any[Source[ByteString, _]]))
+          .thenReturn(EitherT.rightT(None))
+
+        when(
+          messageService
+            .storeIfAppropriate(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Long], any[Source[ByteString, _]])(any[HeaderCarrier])
+        ).thenReturn(EitherT.rightT(BodyStorage.mongo(string)))
+
+        when(
+          movementsRepository.updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            eqTo(now)
+          )
+        ).thenReturn(EitherT.rightT((): Unit))
+
+        when(movementsRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(None), eqTo(None), eqTo(nowMinusOne)))
+          .thenReturn(EitherT.leftT(MongoError.UpdateNotAcknowledged("bleh")))
+
+        val request                = FakeRequest("POST", "/", FakeHeaders(Seq("x-message-type" -> messageType.code)), Source.single(ByteString(string)))
+        val result: Future[Result] = sut.createBody(eori, movementType, movementId, messageId)(request)
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+    }
+
+    def createController(): ControllerAndMocks = {
+      implicit val tfc: TemporaryFileCreator = SingletonTemporaryFileCreator
+
+      val mockRepository: MovementsRepository                        = mock[MovementsRepository]
+      val mockObjectStoreService: ObjectStoreService                 = mock[ObjectStoreService]
+      val mockMessagesXmlParsingService: MessagesXmlParsingService   = mock[MessagesXmlParsingService]
+      val mockMovementsXmlParsingService: MovementsXmlParsingService = mock[MovementsXmlParsingService]
+      val mockMessageService: MessageService                         = mock[MessageService]
+
+      val controller = new MessageBodyController(
+        stubControllerComponents(),
+        mockRepository,
+        mockObjectStoreService,
+        mockMessagesXmlParsingService,
+        mockMovementsXmlParsingService,
+        mockMessageService,
+        clock
+      )
+
+      ControllerAndMocks(controller, mockRepository, mockObjectStoreService, mockMessagesXmlParsingService, mockMovementsXmlParsingService, mockMessageService)
+    }
+
+    case class ControllerAndMocks(
+      controller: MessageBodyController,
+      mockRepository: MovementsRepository,
+      mockObjectStoreService: ObjectStoreService,
+      mockMessagesXmlParsingService: MessagesXmlParsingService,
+      mockMovementsXmlParsingService: MovementsXmlParsingService,
+      mockMessageService: MessageService
+    )
+
   }
 
 }

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -22,7 +22,6 @@ import akka.util.Timeout
 import cats.data.EitherT
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.MockitoSugar.reset
@@ -62,7 +61,6 @@ import uk.gov.hmrc.transitmovements.config.AppConfig
 import uk.gov.hmrc.transitmovements.generators.ModelGenerators
 import uk.gov.hmrc.transitmovements.models._
 import uk.gov.hmrc.transitmovements.models.formats.PresentationFormats
-import uk.gov.hmrc.transitmovements.models.requests
 import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
@@ -168,7 +166,7 @@ class MovementsControllerSpec
     super.beforeEach()
   }
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     reset(mockTemporaryFileCreator)
     reset(mockMessagesXmlParsingService)
     reset(mockMessageFactory)
@@ -208,11 +206,7 @@ class MovementsControllerSpec
     lazy val messageFactoryEither: EitherT[Future, StreamError, Message] =
       EitherT.rightT(message)
 
-    lazy val objectSummaryEither: EitherT[Future, ObjectStoreError, ObjectSummaryWithMd5] = EitherT.rightT(objectSummary)
-
     lazy val received = OffsetDateTime.now(ZoneId.of("UTC"))
-
-    lazy val source: Source[ByteString, _] = Source.single(ByteString("this is test content"))
 
     lazy val uri = new URI("test")
 
@@ -445,24 +439,9 @@ class MovementsControllerSpec
 
     lazy val received = OffsetDateTime.now(ZoneId.of("UTC"))
 
-    lazy val source: Source[ByteString, _] = Source.single(ByteString("this is test content"))
-
     lazy val uri = new URI("test")
 
     lazy val size = Gen.chooseNum(1L, 25000L).sample.value
-
-    lazy val message =
-      Message(
-        messageId,
-        received,
-        Some(received),
-        MessageType.ArrivalNotification,
-        Some(messageId),
-        Some(uri),
-        Some("content"),
-        Some(size),
-        Some(MessageStatus.Processing)
-      )
 
     "must return OK if XML data extraction is successful" in {
 

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -1257,7 +1257,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1287,7 +1287,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1320,7 +1320,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1350,7 +1350,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
@@ -1374,7 +1374,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1404,7 +1404,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1439,7 +1439,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1473,7 +1473,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(0)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1487,7 +1487,7 @@ class MovementsControllerSpec
       ) {
         (eori, movementType, messageStatus) =>
           reset(mockRepository) // needed thanks to the generators running the test multiple times.
-          val expectedUpdateMessageMetadata = requests.UpdateMessageMetadata(None, messageStatus, None)
+          val expectedUpdateData = UpdateMessageData(status = messageStatus)
 
           when(
             mockRepository.getMovementWithoutMessages(eqTo(eori), MovementId(eqTo(movementId.value)), eqTo(movementType))
@@ -1500,7 +1500,7 @@ class MovementsControllerSpec
             mockRepository.updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              eqTo(expectedUpdateMessageMetadata),
+              eqTo(expectedUpdateData),
               any[OffsetDateTime]
             )
           )
@@ -1524,7 +1524,7 @@ class MovementsControllerSpec
           verify(mockRepository, times(1)).updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            any[UpdateMessageMetadata],
+            any[UpdateMessageData],
             any[OffsetDateTime]
           )
           verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1562,7 +1562,7 @@ class MovementsControllerSpec
             mockRepository.updateMessage(
               any[String].asInstanceOf[MovementId],
               any[String].asInstanceOf[MessageId],
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
           )
@@ -1602,7 +1602,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1627,7 +1627,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1649,7 +1649,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1674,7 +1674,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
@@ -1710,7 +1710,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1741,7 +1741,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
@@ -1774,7 +1774,7 @@ class MovementsControllerSpec
               mockRepository.updateMessage(
                 MovementId(eqTo(movementId.value)),
                 MessageId(eqTo(messageId.value)),
-                any[UpdateMessageMetadata],
+                any[UpdateMessageData],
                 any[OffsetDateTime]
               )
             )
@@ -1805,7 +1805,7 @@ class MovementsControllerSpec
             verify(mockRepository, times(1)).updateMessage(
               MovementId(eqTo(movementId.value)),
               MessageId(eqTo(messageId.value)),
-              any[UpdateMessageMetadata],
+              any[UpdateMessageData],
               any[OffsetDateTime]
             )
             verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
@@ -1870,7 +1870,7 @@ class MovementsControllerSpec
     ) {
       (movementId, messageId, messageStatus) =>
         reset(mockRepository) // needed thanks to the generators running the test multiple times.
-        val expectedUpdateMessageMetadata = requests.UpdateMessageMetadata(None, messageStatus, None)
+        val expectedUpdateMessageMetadata = UpdateMessageData(status = messageStatus)
 
         when(
           mockRepository.updateMessage(
@@ -1900,7 +1900,7 @@ class MovementsControllerSpec
         verify(mockRepository, times(1)).updateMessage(
           MovementId(eqTo(movementId.value)),
           MessageId(eqTo(messageId.value)),
-          any[UpdateMessageMetadata],
+          any[UpdateMessageData],
           any[OffsetDateTime]
         )
     }
@@ -1931,7 +1931,7 @@ class MovementsControllerSpec
     "must return NOT_FOUND when an incorrect message is specified" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageStatus]) {
       (movementId, messageId, messageStatus) =>
         reset(mockRepository) // needed thanks to the generators running the test multiple times.
-        val expectedUpdateMessageMetadata = requests.UpdateMessageMetadata(None, messageStatus, None)
+        val expectedUpdateMessageMetadata = UpdateMessageData(status = messageStatus)
 
         when(
           mockRepository.updateMessage(

--- a/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovements/generators/ModelGenerators.scala
@@ -123,7 +123,7 @@ trait ModelGenerators extends BaseGenerators {
       for {
         id             <- arbitrary[MessageId]
         offsetDateTime <- arbitrary[OffsetDateTime]
-        messageType    <- arbitrary[MessageType]
+        messageType    <- Gen.option(arbitrary[MessageType])
         status         <- Gen.oneOf(MessageStatus.statusValues)
       } yield MessageResponse(id, offsetDateTime, messageType, None, Some(status))
     }

--- a/test/uk/gov/hmrc/transitmovements/matchers/UpdateMessageDataMatcher.scala
+++ b/test/uk/gov/hmrc/transitmovements/matchers/UpdateMessageDataMatcher.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.matchers
+
+import org.mockito.ArgumentMatcher
+import uk.gov.hmrc.transitmovements.models.MessageStatus
+import uk.gov.hmrc.transitmovements.models.MessageType
+import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
+import uk.gov.hmrc.transitmovements.models.UpdateMessageData
+
+case class UpdateMessageDataMatcher(
+  objectStoreURI: Option[ObjectStoreURI] = None,
+  body: Option[String] = None,
+  status: MessageStatus,
+  messageType: Option[MessageType] = None,
+  expectSize: Boolean = true
+) extends ArgumentMatcher[UpdateMessageData] {
+
+  // intentionally ignores size, other than to check it's there
+  override def matches(argument: UpdateMessageData): Boolean =
+    argument.body == body &&
+      argument.messageType == messageType &&
+      argument.status == status &&
+      argument.objectStoreURI == objectStoreURI &&
+      argument.size.isDefined == expectSize
+}


### PR DESCRIPTION
Part 3 of the object-store rationalisation, to support CTCP-2452

# What is this PR all about?

Attaching a message body to an empty message via a stream

# What does this PR do?

* Sending a stream to `POST /traders/:EORI/movements/:movementType/:movementId/messages/:messageId/body` will add a message body to an empty movement.
    * 201 on creation
    * 404 if the message ID or movement ID doesn't exist
    * 409 (conflict) if the message body already exists (this is why we're using POST, it's not idempotent)
    * 400 if the XML is bad
    * 500 if something goes wrong
* Message status on `MessageResponse` is now optional
* Retains `UpdateMessageMetadata` solely as a presentation layer object, `UpdateMessageData` is now the data transfer object to Mongo

# What's next?

This should be it for `transit-movements` for now, apart from supporting receiving upscan URLs instead of object-store, but that's not a blocker right this moment. Next, once this has settled, we'll go around other repos and point them at better places here instead of object store, then change the owner of everything from `common-transit-convention-traders` to `transit-movements`.