### PR TITLE
CTCP-2774: Ensure we extract anything that's appropriate from a message

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MessageBodyController.scala
@@ -101,7 +101,14 @@ class MessageBodyController @Inject() (
             .updateMessage(
               movementId,
               messageId,
-              UpdateMessageData(bodyStorage.objectStore, bodyStorage.mongo, Some(size), messageType.statusOnAttach, Some(messageType)),
+              UpdateMessageData(
+                bodyStorage.objectStore,
+                bodyStorage.mongo,
+                Some(size),
+                messageType.statusOnAttach,
+                Some(messageType),
+                Some(messageData.generationDate)
+              ),
               received
             )
             .asPresentation

--- a/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/MovementsController.scala
@@ -152,7 +152,7 @@ class MovementsController @Inject() (
       case None    => attachLargeMessage(movementId, triggerId)
     }
 
-  private def attachLargeMessage(movementId: MovementId, triggerId: Option[MessageId] = None): Action[AnyContent] = Action.async(parse.anyContent) {
+  private def attachLargeMessage(movementId: MovementId, triggerId: Option[MessageId]): Action[AnyContent] = Action.async(parse.anyContent) {
     implicit request =>
       request.headers.get(Constants.ObjectStoreURI).map(ObjectStoreURI.apply) match {
         case Some(objectStoreURI) => updateMovementWithObjectStoreURI(movementId, objectStoreURI, triggerId)

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.transitmovements.controllers.errors
 
 import cats.data.EitherT
+import play.api.Logging
 import uk.gov.hmrc.transitmovements.services.errors.MongoError
 import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError
 import uk.gov.hmrc.transitmovements.services.errors.ObjectStoreError.FileNotFound
@@ -27,6 +28,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 trait ConvertError {
+  self: Logging =>
 
   implicit class ErrorConverter[E, A](value: EitherT[Future, E, A]) {
 

--- a/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovements/controllers/errors/ConvertError.scala
@@ -33,7 +33,23 @@ trait ConvertError {
   implicit class ErrorConverter[E, A](value: EitherT[Future, E, A]) {
 
     def asPresentation(implicit c: Converter[E], ec: ExecutionContext): EitherT[Future, PresentationError, A] =
-      value.leftMap(c.convert)
+      value.leftMap(c.convert).leftSemiflatTap {
+        case InternalServiceError(message, _, cause) =>
+          val causeText = cause
+            .map {
+              ex =>
+                s"""
+                |Message: ${ex.getMessage}
+                |Trace: ${ex.getStackTrace.mkString(System.lineSeparator())}
+                |""".stripMargin
+            }
+            .getOrElse("No exception is available")
+          logger.error(s"""Internal Server Error: $message
+               |
+               |$causeText""".stripMargin)
+          Future.successful(())
+        case _ => Future.successful(())
+      }
   }
 
   sealed trait Converter[E] {

--- a/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
@@ -16,6 +16,12 @@
 
 package uk.gov.hmrc.transitmovements.models
 
+import play.api.libs.json.JsError
+import play.api.libs.json.JsString
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Reads
+import play.api.libs.json.Writes
+
 sealed trait MessageType extends Product with Serializable {
   def code: String
   def rootNode: String
@@ -71,6 +77,17 @@ sealed abstract class ErrorMessageType(val code: String, val rootNode: String, v
     with DepartureMessageType
 
 object MessageType {
+
+  implicit val messageTokenWrites: Writes[MessageType] = Writes {
+    t => JsString(t.code)
+  }
+
+  implicit val messageTokenReads: Reads[MessageType] = Reads {
+    case JsString(value) =>
+      values.find(_.code == value).map(JsSuccess(_)).getOrElse(JsError(s"Message type $value could not be found"))
+    case x => JsError(s"Invalid value: $x")
+  }
+
   // *******************
   // Departures Requests
   // *******************

--- a/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/MessageType.scala
@@ -78,11 +78,11 @@ sealed abstract class ErrorMessageType(val code: String, val rootNode: String, v
 
 object MessageType {
 
-  implicit val messageTokenWrites: Writes[MessageType] = Writes {
+  implicit val messageTypeWrites: Writes[MessageType] = Writes {
     t => JsString(t.code)
   }
 
-  implicit val messageTokenReads: Reads[MessageType] = Reads {
+  implicit val messageTypeReads: Reads[MessageType] = Reads {
     case JsString(value) =>
       values.find(_.code == value).map(JsSuccess(_)).getOrElse(JsError(s"Message type $value could not be found"))
     case x => JsError(s"Invalid value: $x")

--- a/app/uk/gov/hmrc/transitmovements/models/UpdateMessageData.scala
+++ b/app/uk/gov/hmrc/transitmovements/models/UpdateMessageData.scala
@@ -19,9 +19,13 @@ package uk.gov.hmrc.transitmovements.models
 import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.requests.UpdateStatus
 
+import java.time.OffsetDateTime
+
 object UpdateMessageData {
-  def apply(status: UpdateStatus): UpdateMessageData            = UpdateMessageData(None, None, None, status.status, None)
-  def apply(metadata: UpdateMessageMetadata): UpdateMessageData = UpdateMessageData(metadata.objectStoreURI, None, None, metadata.status, metadata.messageType)
+  def apply(status: UpdateStatus): UpdateMessageData = UpdateMessageData(None, None, None, status.status, None)
+
+  def apply(metadata: UpdateMessageMetadata, generationDate: Option[OffsetDateTime]): UpdateMessageData =
+    UpdateMessageData(metadata.objectStoreURI, None, None, metadata.status, metadata.messageType, generationDate)
 }
 
 final case class UpdateMessageData(
@@ -29,5 +33,6 @@ final case class UpdateMessageData(
   body: Option[String] = None,
   size: Option[Long] = None,
   status: MessageStatus,
-  messageType: Option[MessageType] = None
+  messageType: Option[MessageType] = None,
+  generationDate: Option[OffsetDateTime] = None
 )

--- a/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
+++ b/app/uk/gov/hmrc/transitmovements/repositories/MovementsRepository.scala
@@ -359,7 +359,8 @@ class MovementsRepositoryImpl @Inject() (
       createSet("messages.$[element].uri", message.objectStoreURI.map(_.value)) ++
       createSet("messages.$[element].body", message.body) ++
       createSet("messages.$[element].size", message.size) ++
-      createSet("messages.$[element].messageType", message.messageType.map(_.code))
+      createSet("messages.$[element].messageType", message.messageType.map(_.code)) ++
+      createSet("messages.$[element].generated", message.generationDate)
 
     executeUpdate(movementId, filter, combined, arrayFilters)
   }

--- a/app/uk/gov/hmrc/transitmovements/utils/StreamWithFile.scala
+++ b/app/uk/gov/hmrc/transitmovements/utils/StreamWithFile.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.utils
+
+import akka.stream.IOResult
+import akka.stream.Materializer
+import akka.stream.scaladsl.FileIO
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import cats.syntax.flatMap._
+import play.api.Logging
+import play.api.libs.Files.TemporaryFileCreator
+import uk.gov.hmrc.transitmovements.controllers.errors.PresentationError
+
+import java.nio.file.Path
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait StreamWithFile {
+  self: Logging =>
+
+  def withReusableSource[R](
+    src: Source[ByteString, _]
+  )(
+    block: Source[ByteString, _] => EitherT[Future, PresentationError, R]
+  )(implicit temporaryFileCreator: TemporaryFileCreator, mat: Materializer, ec: ExecutionContext): EitherT[Future, PresentationError, R] = {
+    val file = temporaryFileCreator.create()
+    (for {
+      _      <- writeToFile(file, src)
+      result <- block(FileIO.fromPath(file))
+    } yield result)
+      .flatTap {
+        _ =>
+          file.delete()
+          EitherT.rightT(())
+      }
+
+  }
+
+  private def writeToFile(file: Path, src: Source[ByteString, _])(implicit
+    mat: Materializer,
+    ec: ExecutionContext
+  ): EitherT[Future, PresentationError, IOResult] =
+    EitherT(
+      src
+        .runWith(FileIO.toPath(file))
+        .map(Right.apply)
+        .recover {
+          case NonFatal(thr) =>
+            logger.error(s"Failed to create file stream: $thr", thr)
+            Left(PresentationError.internalServiceError(cause = Some(thr)))
+        }
+    )
+
+}

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -37,6 +37,7 @@ import uk.gov.hmrc.transitmovements.services.errors.MongoError
 
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MovementsRepositorySpec
@@ -722,6 +723,55 @@ class MovementsRepositorySpec
         message.uri.value.toString shouldBe message2.objectStoreURI.get.value
         message.messageType.code shouldBe message2.messageType.get.code
         message.size shouldBe Some(4L)
+    }
+  }
+
+  "updateMessage" should "update the existing message with status, object store url, size, messageType and generationDate" in {
+
+    val message1 =
+      arbitrary[Message].sample.value.copy(body = None, messageType = MessageType.DeclarationData, triggerId = None, status = Some(MessageStatus.Pending))
+
+    val departureMovement =
+      arbitrary[Movement].sample.value
+        .copy(
+          created = instant,
+          updated = instant,
+          messages = Vector(message1)
+        )
+
+    await(
+      repository.insert(departureMovement).value
+    )
+
+    val now = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS)
+
+    val message2 = UpdateMessageData(
+      objectStoreURI = Some(ObjectStoreURI("common-transit-convention-traders/some-url.xml")),
+      status = MessageStatus.Success,
+      size = Option(4L),
+      messageType = Some(MessageType.DeclarationAmendment),
+      generationDate = Some(now)
+    )
+
+    val result = await(
+      repository.updateMessage(departureMovement._id, message1.id, message2, receivedInstant).value
+    )
+
+    result should be(Right(()))
+
+    whenReady(
+      repository.collection.find(Filters.eq("_id", departureMovement._id.value)).first().toFuture()
+    ) {
+      movement =>
+        movement.updated shouldEqual receivedInstant
+        movement.messages.length should be(1)
+
+        val message = movement.messages.head
+        message.status shouldBe Some(message2.status)
+        message.uri.value.toString shouldBe message2.objectStoreURI.get.value
+        message.messageType.code shouldBe message2.messageType.get.code
+        message.size shouldBe Some(4L)
+        message.generated shouldBe Some(now)
     }
   }
 

--- a/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -729,7 +729,7 @@ class MovementsRepositorySpec
   "updateMessage" should "update the existing message with status, object store url, size, messageType and generationDate" in {
 
     val message1 =
-      arbitrary[Message].sample.value.copy(body = None, messageType = MessageType.DeclarationData, triggerId = None, status = Some(MessageStatus.Pending))
+      arbitrary[Message].sample.value.copy(body = None, messageType = Some(MessageType.DeclarationData), triggerId = None, status = Some(MessageStatus.Pending))
 
     val departureMovement =
       arbitrary[Movement].sample.value
@@ -769,7 +769,7 @@ class MovementsRepositorySpec
         val message = movement.messages.head
         message.status shouldBe Some(message2.status)
         message.uri.value.toString shouldBe message2.objectStoreURI.get.value
-        message.messageType.code shouldBe message2.messageType.get.code
+        message.messageType.get.code shouldBe message2.messageType.get.code
         message.size shouldBe Some(4L)
         message.generated shouldBe Some(now)
     }

--- a/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MessageBodyControllerSpec.scala
@@ -545,7 +545,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.rightT((): Unit))
@@ -610,7 +610,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.rightT((): Unit))
@@ -675,7 +675,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.rightT((): Unit))
@@ -741,7 +741,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.rightT((): Unit))
@@ -1142,7 +1142,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.leftT(MongoError.UnexpectedError(None)))
@@ -1205,7 +1205,7 @@ class MessageBodyControllerSpec
           movementsRepository.updateMessage(
             MovementId(eqTo(movementId.value)),
             MessageId(eqTo(messageId.value)),
-            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType))),
+            argThat(UpdateMessageDataMatcher(None, Some(string), messageType.statusOnAttach, Some(messageType), Some(now))),
             eqTo(now)
           )
         ).thenReturn(EitherT.rightT((): Unit))

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -1235,25 +1235,6 @@ class MovementsControllerSpec
       contentAsJson(result) mustBe Json.obj("messageId" -> messageId.value)
     }
 
-    "must return BAD_REQUEST when Object Store uri header not supplied" in {
-
-      lazy val request = FakeRequest(
-        method = "POST",
-        uri = routes.MovementsController.updateMovement(movementId, Some(triggerId)).url,
-        headers = FakeHeaders(Seq("X-Message-Type" -> messageType.code)),
-        body = AnyContentAsEmpty
-      )
-
-      val result =
-        controller.updateMovement(movementId, Some(triggerId))(request)
-
-      status(result) mustBe BAD_REQUEST
-      contentAsJson(result) mustBe Json.obj(
-        "code"    -> "BAD_REQUEST",
-        "message" -> "Missing X-Object-Store-Uri header value"
-      )
-    }
-
     "must return BAD_REQUEST when file not found on object store resource location" in {
 
       when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[ExecutionContext], any[HeaderCarrier]))
@@ -1365,10 +1346,10 @@ class MovementsControllerSpec
             )
               .thenReturn(EitherT.rightT(()))
 
-              when(
-                mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
-              )
-                .thenReturn(EitherT.rightT(()))
+            when(
+              mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
+            )
+              .thenReturn(EitherT.rightT(()))
 
             val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
             val body = Json.obj(
@@ -1383,18 +1364,18 @@ class MovementsControllerSpec
               body = body
             )
 
-              val result =
-                controller.updateMessage(eori, MovementType.Departure, movementId, messageId)(request)
+            val result =
+              controller.updateMessage(eori, MovementType.Departure, movementId, messageId)(request)
 
-              status(result) mustBe OK
-              verify(mockRepository, times(1)).updateMessage(
-                MovementId(eqTo(movementId.value)),
-                MessageId(eqTo(messageId.value)),
-                any[UpdateMessageData],
-                any[OffsetDateTime]
-              )
-              verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
-          }
+            status(result) mustBe OK
+            verify(mockRepository, times(1)).updateMessage(
+              MovementId(eqTo(movementId.value)),
+              MessageId(eqTo(messageId.value)),
+              any[UpdateMessageData],
+              any[OffsetDateTime]
+            )
+            verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
+        }
 
         "if the message is an arrival message and the first one in the movement" in forAll(
           arbitrary[EORINumber],
@@ -1455,10 +1436,10 @@ class MovementsControllerSpec
             )
               .thenReturn(EitherT.rightT(()))
 
-              when(
-                mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
-              )
-                .thenReturn(EitherT.rightT(()))
+            when(
+              mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
+            )
+              .thenReturn(EitherT.rightT(()))
 
             val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
             val body = Json.obj(
@@ -1473,18 +1454,18 @@ class MovementsControllerSpec
               body = body
             )
 
-              val result =
-                controller.updateMessage(eori, MovementType.Arrival, movementId, messageId)(request)
+            val result =
+              controller.updateMessage(eori, MovementType.Arrival, movementId, messageId)(request)
 
-              status(result) mustBe OK
-              verify(mockRepository, times(1)).updateMessage(
-                MovementId(eqTo(movementId.value)),
-                MessageId(eqTo(messageId.value)),
-                any[UpdateMessageData],
-                any[OffsetDateTime]
-              )
-              verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
-          }
+            status(result) mustBe OK
+            verify(mockRepository, times(1)).updateMessage(
+              MovementId(eqTo(movementId.value)),
+              MessageId(eqTo(messageId.value)),
+              any[UpdateMessageData],
+              any[OffsetDateTime]
+            )
+            verify(mockRepository, times(1)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(Some(mrn)), any[OffsetDateTime])
+        }
 
         "if the movement EORI has already been set" in forAll(
           arbitrary[EORINumber],
@@ -1559,8 +1540,8 @@ class MovementsControllerSpec
               body = body
             )
 
-              val result =
-                controller.updateMessage(eori, movementType, movementId, messageId)(request)
+            val result =
+              controller.updateMessage(eori, movementType, movementId, messageId)(request)
 
             status(result) mustBe OK
             verify(mockRepository, times(1)).updateMessage(
@@ -1616,20 +1597,20 @@ class MovementsControllerSpec
             when(mockMessagesXmlParsingService.extractMessageData(any[Source[ByteString, _]], eqTo(messageType)))
               .thenReturn(EitherT.rightT(MessageData(generatedTime, Some(mrn))))
 
-              when(
-                mockRepository.updateMessage(
-                  MovementId(eqTo(movementId.value)),
-                  MessageId(eqTo(messageId.value)),
-                  any[UpdateMessageData],
-                  any[OffsetDateTime]
-                )
+            when(
+              mockRepository.updateMessage(
+                MovementId(eqTo(movementId.value)),
+                MessageId(eqTo(messageId.value)),
+                any[UpdateMessageData],
+                any[OffsetDateTime]
               )
-                .thenReturn(EitherT.rightT(()))
+            )
+              .thenReturn(EitherT.rightT(()))
 
-              when(
-                mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
-              )
-                .thenReturn(EitherT.rightT(()))
+            when(
+              mockRepository.updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
+            )
+              .thenReturn(EitherT.rightT(()))
 
             val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
             val body = Json.obj(
@@ -1647,20 +1628,20 @@ class MovementsControllerSpec
             val result =
               controller.updateMessage(eori, movementType, movementId, messageId)(request)
 
-              status(result) mustBe BAD_REQUEST
-              contentAsJson(result) mustBe Json.obj(
-                "code"    -> "BAD_REQUEST",
-                "message" -> "Provided Object Store URI is not owned by common-transit-convention-traders"
-              )
-              verify(mockRepository, times(0)).updateMessage(
-                MovementId(eqTo(movementId.value)),
-                MessageId(eqTo(messageId.value)),
-                any[UpdateMessageData],
-                any[OffsetDateTime]
-              )
-              verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
-          }
+            status(result) mustBe BAD_REQUEST
+            contentAsJson(result) mustBe Json.obj(
+              "code"    -> "BAD_REQUEST",
+              "message" -> "Provided Object Store URI is not owned by common-transit-convention-traders"
+            )
+            verify(mockRepository, times(0)).updateMessage(
+              MovementId(eqTo(movementId.value)),
+              MessageId(eqTo(messageId.value)),
+              any[UpdateMessageData],
+              any[OffsetDateTime]
+            )
+            verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
         }
+      }
 
       "must return OK, if the update message is successful, given only status is provided in the request" in forAll(
         arbitrary[EORINumber],
@@ -1699,52 +1680,52 @@ class MovementsControllerSpec
           )
             .thenReturn(EitherT.rightT(()))
 
-            val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
-            val body = Json.obj(
-              "status" -> messageStatus.toString
-            )
-            val request = FakeRequest(
-              method = POST,
-              uri = routes.MovementsController.updateMessage(eori, movementType, movementId, messageId).url,
-              headers = headers,
-              body = body
-            )
+          val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
+          val body = Json.obj(
+            "status" -> messageStatus.toString
+          )
+          val request = FakeRequest(
+            method = POST,
+            uri = routes.MovementsController.updateMessage(eori, movementType, movementId, messageId).url,
+            headers = headers,
+            body = body
+          )
 
-            val result =
-              controller.updateMessage(eori, movementType, movementId, messageId)(request)
+          val result =
+            controller.updateMessage(eori, movementType, movementId, messageId)(request)
 
-            status(result) mustBe OK
-            verify(mockRepository, times(1)).updateMessage(
-              MovementId(eqTo(movementId.value)),
-              MessageId(eqTo(messageId.value)),
-              any[UpdateMessageData],
-              any[OffsetDateTime]
-            )
-            verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
-        }
+          status(result) mustBe OK
+          verify(mockRepository, times(1)).updateMessage(
+            MovementId(eqTo(movementId.value)),
+            MessageId(eqTo(messageId.value)),
+            any[UpdateMessageData],
+            any[OffsetDateTime]
+          )
+          verify(mockRepository, times(0)).updateMovement(MovementId(eqTo(movementId.value)), eqTo(Some(eori)), eqTo(None), any[OffsetDateTime])
+      }
 
-        "must return BAD_REQUEST when JSON data extraction fails" in forAll(arbitrary[EORINumber], arbitrary[MovementType]) {
-          (eori, messageType) =>
-            val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
-            val body = Json.obj(
-              "objectStoreURI" -> "common-transit-convention-traders/something.xml"
-            )
-            val request = FakeRequest(
-              method = POST,
-              uri = routes.MovementsController.updateMessage(eori, messageType, movementId, messageId).url,
-              headers = headers,
-              body = body
-            )
+      "must return BAD_REQUEST when JSON data extraction fails" in forAll(arbitrary[EORINumber], arbitrary[MovementType]) {
+        (eori, messageType) =>
+          val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON))
+          val body = Json.obj(
+            "objectStoreURI" -> "common-transit-convention-traders/something.xml"
+          )
+          val request = FakeRequest(
+            method = POST,
+            uri = routes.MovementsController.updateMessage(eori, messageType, movementId, messageId).url,
+            headers = headers,
+            body = body
+          )
 
-            val result =
-              controller.updateMessage(eori, messageType, movementId, messageId)(request)
+          val result =
+            controller.updateMessage(eori, messageType, movementId, messageId)(request)
 
-            status(result) mustBe BAD_REQUEST
-            contentAsJson(result) mustBe Json.obj(
-              "code"    -> "BAD_REQUEST",
-              "message" -> "Could not parse the request"
-            )
-        }
+          status(result) mustBe BAD_REQUEST
+          contentAsJson(result) mustBe Json.obj(
+            "code"    -> "BAD_REQUEST",
+            "message" -> "Could not parse the request"
+          )
+      }
 
       "must return BAD REQUEST, if the update message is unsuccessful, given invalid status is provided in the request" in forAll(
         arbitrary[EORINumber],

--- a/test/uk/gov/hmrc/transitmovements/controllers/errors/ConvertErrorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/errors/ConvertErrorSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Logging
 import uk.gov.hmrc.transitmovements.controllers.errors.ErrorCode.BadRequest
 import uk.gov.hmrc.transitmovements.controllers.errors.ErrorCode.InternalServerError
 import uk.gov.hmrc.transitmovements.controllers.errors.ErrorCode.NotFound
@@ -35,7 +36,7 @@ import scala.concurrent.Future
 
 class ConvertErrorSpec extends AnyFreeSpec with Matchers with OptionValues with ScalaFutures with MockitoSugar {
 
-  object Harness extends ConvertError
+  object Harness extends ConvertError with Logging
 
   import Harness._
 

--- a/test/uk/gov/hmrc/transitmovements/matchers/UpdateMessageDataMatcher.scala
+++ b/test/uk/gov/hmrc/transitmovements/matchers/UpdateMessageDataMatcher.scala
@@ -22,11 +22,14 @@ import uk.gov.hmrc.transitmovements.models.MessageType
 import uk.gov.hmrc.transitmovements.models.ObjectStoreURI
 import uk.gov.hmrc.transitmovements.models.UpdateMessageData
 
+import java.time.OffsetDateTime
+
 case class UpdateMessageDataMatcher(
   objectStoreURI: Option[ObjectStoreURI] = None,
   body: Option[String] = None,
   status: MessageStatus,
   messageType: Option[MessageType] = None,
+  generationDate: Option[OffsetDateTime] = None,
   expectSize: Boolean = true
 ) extends ArgumentMatcher[UpdateMessageData] {
 
@@ -36,5 +39,6 @@ case class UpdateMessageDataMatcher(
       argument.messageType == messageType &&
       argument.status == status &&
       argument.objectStoreURI == objectStoreURI &&
+      argument.generationDate == generationDate &&
       argument.size.isDefined == expectSize
 }

--- a/test/uk/gov/hmrc/transitmovements/models/MessageTypeSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/models/MessageTypeSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.models
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.JsError
+import play.api.libs.json.JsNull
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsString
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
+import uk.gov.hmrc.transitmovements.generators.ModelGenerators
+
+class MessageTypeSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks with ModelGenerators {
+
+  "messageTypeReads" - {
+    "reads should return the message type code only" in forAll(arbitrary[MessageType]) {
+      messageType =>
+        MessageType.messageTypeReads.reads(JsString(messageType.code)) mustBe JsSuccess(messageType)
+    }
+
+    "reads should return an error for an unsupported type" in forAll(Gen.oneOf(JsNull, JsNumber(1), Json.obj())) {
+      badObject =>
+        MessageType.messageTypeReads.reads(badObject) mustBe JsError(s"Invalid value: $badObject")
+    }
+  }
+
+  "messageTypeWrites" - {
+    "writes should only write the code as a JsString" in forAll(arbitrary[MessageType]) {
+      messageType =>
+        MessageType.messageTypeWrites.writes(messageType) mustBe JsString(messageType.code)
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/transitmovements/services/MessageServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/services/MessageServiceImplSpec.scala
@@ -114,7 +114,6 @@ class MessageServiceImplSpec extends SpecBase with ScalaFutures with Matchers wi
 
         whenReady(result.value) {
           r =>
-            println(Mockito.mockingDetails(smallMessageLimitServiceMock).printInvocations())
             r mustBe Right(
               Message(
                 messageId,

--- a/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
@@ -30,6 +30,7 @@ import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.Files.TemporaryFileCreator
 import uk.gov.hmrc.transitmovements.base.TestActorSystem
 import uk.gov.hmrc.transitmovements.base.TestSourceProvider
+import uk.gov.hmrc.transitmovements.controllers.errors.PresentationError
 
 import java.nio.file.Path
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/utils/StreamWithFileSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovements.utils
+
+import akka.stream.scaladsl.Sink
+import cats.data.EitherT
+import org.scalacheck.Gen
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.Logging
+import play.api.libs.Files
+import play.api.libs.Files.SingletonTemporaryFileCreator
+import play.api.libs.Files.TemporaryFileCreator
+import uk.gov.hmrc.transitmovements.base.TestActorSystem
+import uk.gov.hmrc.transitmovements.base.TestSourceProvider
+
+import java.nio.file.Path
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.io.Source
+import scala.util.Success
+import scala.util.Try
+
+class StreamWithFileSpec
+    extends AnyFreeSpec
+    with TestActorSystem
+    with Matchers
+    with TestSourceProvider
+    with ScalaCheckDrivenPropertyChecks
+    with OptionValues
+    with ScalaFutures {
+
+  case class DummyTemporaryFileCreator(temporaryFile: Files.TemporaryFile) extends TemporaryFileCreator {
+
+    override def create(prefix: String, suffix: String): Files.TemporaryFile = temporaryFile
+
+    override def create(path: Path): Files.TemporaryFile = temporaryFile
+
+    override def delete(file: Files.TemporaryFile): Try[Boolean] = Success(true)
+  }
+
+  "withReusableSource" - {
+    object Harness extends StreamWithFile with Logging
+
+    "using a reusable source on a single use source should create a file when streamed once" in {
+
+      // create the file now so we can check it later.
+      implicit val temporaryFileCreator: DummyTemporaryFileCreator = DummyTemporaryFileCreator(SingletonTemporaryFileCreator.create())
+      temporaryFileCreator.temporaryFile.deleteOnExit()
+
+      val string = Gen.stringOfN(10, Gen.alphaNumChar).sample.value
+      val source = singleUseStringSource(string)
+
+      Harness.withReusableSource(source) {
+        source =>
+          EitherT[Future, PresentationError, Unit] {
+            source
+              .runWith(Sink.ignore)
+              .map {
+                _ =>
+                  // we now load the file and it should contain the string
+                  val fileContents = Source.fromFile(temporaryFileCreator.temporaryFile.toFile)
+                  try fileContents.mkString mustBe string
+                  finally fileContents.close()
+                  Right(()) // this simply fulfils the contract
+              }
+          }
+      }
+    }
+
+    "using a reusable source on a single use source can be used multiple times in succession and get the same result" in {
+
+      // create the file now so we can check it later.
+      implicit val temporaryFileCreator: DummyTemporaryFileCreator = DummyTemporaryFileCreator(SingletonTemporaryFileCreator.create())
+      temporaryFileCreator.temporaryFile.deleteOnExit()
+
+      val string = Gen.stringOfN(10, Gen.alphaNumChar).sample.value
+      val source = singleUseStringSource(string)
+
+      Harness.withReusableSource(source) {
+        source =>
+          val future = for {
+            first  <- source.runWith(Sink.head).map(_.utf8String)
+            second <- source.runWith(Sink.head).map(_.utf8String)
+            third  <- source.runWith(Sink.head).map(_.utf8String)
+            fourth <- source.runWith(Sink.head).map(_.utf8String)
+          } yield (first, second, third, fourth)
+
+          whenReady(future) {
+            result =>
+              result._1 mustBe string
+              result._2 mustBe string
+              result._3 mustBe string
+              result._4 mustBe string
+          }
+
+          EitherT.rightT[Future, PresentationError](())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Also add logging if we have an internal server error -- do people think that's a good idea?

The extraction code in transit-movements is a mess and should be consolidated... but that's a tech debt ticket.