### PR TITLE
CTCP-3705: Add configuration for disabling LRN check

### DIFF
--- a/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovements/config/AppConfig.scala
@@ -37,4 +37,6 @@ class AppConfig @Inject() (
 
   lazy val smallMessageSizeLimit: Long  = config.get[Long]("smallMessageSizeLimit")
   lazy val internalAuthEnabled: Boolean = config.get[Boolean]("microservice.services.internal-auth.enabled")
+
+  lazy val lrnDuplicateCheck: Boolean = config.get[Boolean]("checkDuplicateLRN")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -140,3 +140,4 @@ object-store.default-retention-period = 1-month
 
 internal-auth.token = "transit-movements-token"
 smallMessageSizeLimit = 500000
+checkDuplicateLRN = true

--- a/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovements/controllers/MovementsControllerSpec.scala
@@ -61,7 +61,6 @@ import uk.gov.hmrc.internalauth.client.Predicate
 import uk.gov.hmrc.internalauth.client.Resource
 import uk.gov.hmrc.internalauth.client.ResourceLocation
 import uk.gov.hmrc.internalauth.client.ResourceType
-import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
 import uk.gov.hmrc.transitmovements.base.SpecBase
 import uk.gov.hmrc.transitmovements.base.TestActorSystem
 import uk.gov.hmrc.transitmovements.config.AppConfig
@@ -70,7 +69,6 @@ import uk.gov.hmrc.transitmovements.generators.ModelGenerators
 import uk.gov.hmrc.transitmovements.matchers.UpdateMessageDataMatcher
 import uk.gov.hmrc.transitmovements.models._
 import uk.gov.hmrc.transitmovements.models.formats.PresentationFormats
-import uk.gov.hmrc.transitmovements.models.requests.UpdateMessageMetadata
 import uk.gov.hmrc.transitmovements.models.responses.MessageResponse
 import uk.gov.hmrc.transitmovements.repositories.MovementsRepository
 import uk.gov.hmrc.transitmovements.services._


### PR DESCRIPTION
For now, rather than remove the check, we just need to be able to not do it on a per-environment basis -- so we have a config option to toggle when the time is right.

We will want to delete this function later, but when everything is working up to ET.