### PR TITLE
CTCP6-72

### DIFF
--- a/it/test/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/transitmovements/repositories/MovementsRepositorySpec.scala
@@ -243,8 +243,17 @@ class MovementsRepositorySpec
     result.toOption.isEmpty should be(true)
   }
 
-  "getMovementEori" should "return MovementWithEori if it exists" in {
-    val movement = arbitrary[MongoMovement].sample.value
+  "getMovementEori" should "return MovementWithEori if it exists if is transitional is true" in {
+    val movement = arbitrary[MongoMovement].sample.value.copy(isTransitional = true.some)
+
+    await(repository.collection.insertOne(movement).toFuture())
+
+    val result = await(repository.getMovementEori(movement._id).value)
+    result.toOption.get should be(expectedMovementWithEori(movement))
+  }
+
+  "getMovementEori" should "return MovementWithEori if it exists if is transitional is false" in {
+    val movement = arbitrary[MongoMovement].sample.value.copy(isTransitional = false.some)
 
     await(repository.collection.insertOne(movement).toFuture())
 


### PR DESCRIPTION
Modified the tests to prevent random failures. The reason the failure happens is because when isTransitional = None then the code will manipulate that result to be true and the test does not cater for that. 

Note: This logic can be removed at a later point